### PR TITLE
Treat primitive values as nullable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ openapiGeneratorIgnoreList:
   - Rakefile
 openapiNormalizer:
   SET_TAGS_FOR_ALL_OPERATIONS: pinwheel
+  SET_PRIMITIVE_TYPES_TO_NULLABLE: string|integer|number|boolean
 additionalProperties:
   hideGenerationTimestamp: "true"
   gemName: pinwheel

--- a/docs/PinwheelApi.md
+++ b/docs/PinwheelApi.md
@@ -1328,7 +1328,7 @@ pinwheel_version = '2023-11-22' # String | Version identifier specifying how the
 opts = {
   link_token_id: '38400000-8cf0-11bd-b23e-10b96e4ef00d', # String | UUID of the link token triggering the job.
   account_id: '38400000-8cf0-11bd-b23e-10b96e4ef00d', # String | UUID of the payroll account.
-  job_types: ['direct_deposit_switch'], # Array<String> | List of job types. May be expanded to include new enum values (see our Change Management policy).
+  job_types: ['shifts'], # Array<String> | List of job types. May be expanded to include new enum values (see our Change Management policy).
   outcome: TODO, # String | The outcome of the job.
   limit: 56, # Integer | The maximum number of results to return.
   cursor: 'cursor_example', # String | Cursor for the page you want to retrieve.
@@ -2117,7 +2117,7 @@ api_instance = Pinwheel::PinwheelApi.new
 q = 'q_example' # String | Search query on the employer/platform name.
 pinwheel_version = '2023-11-22' # String | Version identifier specifying how the Pinwheel API should behave. See the Change Management page for more information.
 opts = {
-  supported_jobs: ['direct_deposit_switch'], # Array<String> | Filter on supported jobs. Multiple keys are allowed. May be expanded to include new enum values (see our Change Management policy).
+  supported_jobs: ['shifts'], # Array<String> | Filter on supported jobs. Multiple keys are allowed. May be expanded to include new enum values (see our Change Management policy).
   response_types: ['employer'], # Array<String> | Filter on response type. Multiple keys are allowed. May be expanded to include new enum values (see our Change Management policy).
   amount_supported: true, # Boolean | Filter on amount_supported. If true, results that support setting a specific dollar amount for direct deposit switches will be returned. If false, results that support setting a specific dollar amount for direct deposit switches will be excluded.
   platform_type: TODO, # String | If included, filters results by the platform `type`. Platforms are either `payroll` or `time_and_attendance`. Most platforms are `payroll`. Payroll platforms support operations such as updating direct deposit allocation settings. Time & Attendance platforms contain data around shifts and hours worked, but do not support payroll operations.
@@ -3215,7 +3215,7 @@ end
 
 api_instance = Pinwheel::PinwheelApi.new
 pinwheel_version = '2023-11-22' # String | Version identifier specifying how the Pinwheel API should behave. See the Change Management page for more information.
-webhook_create_v20230418 = Pinwheel::WebhookCreateV20230418.new({url: 'url_example', status: 'active', enabled_events: ['shifts.fully_synced'], version: '2023-11-22'}) # WebhookCreateV20230418 | 
+webhook_create_v20230418 = Pinwheel::WebhookCreateV20230418.new({url: 'url_example', status: 'active', enabled_events: ['account.added'], version: '2023-04-18'}) # WebhookCreateV20230418 | 
 
 begin
   # Create Webhook

--- a/lib/pinwheel/api/pinwheel_api.rb
+++ b/lib/pinwheel/api/pinwheel_api.rb
@@ -39,15 +39,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.auth_v1_admin_token_post ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.auth_v1_admin_token_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # verify the required parameter 'create_admin_token_request' is set
       if @api_client.config.client_side_validation && create_admin_token_request.nil?
         fail ArgumentError, "Missing the required parameter 'create_admin_token_request' when calling PinwheelApi.auth_v1_admin_token_post"
@@ -121,15 +112,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.create_key_v1_admin_api_keys_post ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.create_key_v1_admin_api_keys_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/admin/api_keys"
 
@@ -198,19 +180,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.delete_v1_webhooks_webhook_id_delete ..."
       end
-      # verify the required parameter 'webhook_id' is set
-      if @api_client.config.client_side_validation && webhook_id.nil?
-        fail ArgumentError, "Missing the required parameter 'webhook_id' when calling PinwheelApi.delete_v1_webhooks_webhook_id_delete"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.delete_v1_webhooks_webhook_id_delete"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/webhooks/{webhook_id}".sub("{" + "webhook_id" + "}", CGI.escape(webhook_id.to_s).gsub("%2F", "/"))
 
@@ -273,19 +242,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.disable_monitoring_v1_accounts_account_id_disable_monitoring_post ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.disable_monitoring_v1_accounts_account_id_disable_monitoring_post"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.disable_monitoring_v1_accounts_account_id_disable_monitoring_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/accounts/{account_id}/disable_monitoring".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
 
@@ -346,19 +302,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.disconnect_v1_accounts_account_id_disconnect_post ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.disconnect_v1_accounts_account_id_disconnect_post"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.disconnect_v1_accounts_account_id_disconnect_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/accounts/{account_id}/disconnect".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
 
@@ -418,19 +361,6 @@ module Pinwheel
     def get_account_v1_accounts_account_id_get_with_http_info(account_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_account_v1_accounts_account_id_get ..."
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_account_v1_accounts_account_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_account_v1_accounts_account_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/accounts/{account_id}".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
@@ -493,19 +423,6 @@ module Pinwheel
     def get_direct_deposit_allocations_v1_accounts_account_id_direct_deposit_allocations_get_with_http_info(account_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_direct_deposit_allocations_v1_accounts_account_id_direct_deposit_allocations_get ..."
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_direct_deposit_allocations_v1_accounts_account_id_direct_deposit_allocations_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_direct_deposit_allocations_v1_accounts_account_id_direct_deposit_allocations_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/accounts/{account_id}/direct_deposit_allocations".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
@@ -572,19 +489,6 @@ module Pinwheel
     def get_earnings_stream_payouts_v1_end_users_end_user_id_earnings_stream_payouts_get_with_http_info(end_user_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_earnings_stream_payouts_v1_end_users_end_user_id_earnings_stream_payouts_get ..."
-      end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_earnings_stream_payouts_v1_end_users_end_user_id_earnings_stream_payouts_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_earnings_stream_payouts_v1_end_users_end_user_id_earnings_stream_payouts_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_earnings_stream_payouts_v1_end_users_end_user_id_earnings_stream_payouts_get, must be smaller than or equal to 100.'
@@ -658,19 +562,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_employer_v1_employers_employer_id_get ..."
       end
-      # verify the required parameter 'employer_id' is set
-      if @api_client.config.client_side_validation && employer_id.nil?
-        fail ArgumentError, "Missing the required parameter 'employer_id' when calling PinwheelApi.get_employer_v1_employers_employer_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_employer_v1_employers_employer_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/employers/{employer_id}".sub("{" + "employer_id" + "}", CGI.escape(employer_id.to_s).gsub("%2F", "/"))
 
@@ -732,19 +623,6 @@ module Pinwheel
     def get_employment_v1_accounts_account_id_employment_get_with_http_info(account_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_employment_v1_accounts_account_id_employment_get ..."
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_employment_v1_accounts_account_id_employment_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_employment_v1_accounts_account_id_employment_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/accounts/{account_id}/employment".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
@@ -811,19 +689,6 @@ module Pinwheel
     def get_end_user_accounts_v1_end_users_end_user_id_accounts_get_with_http_info(end_user_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_end_user_accounts_v1_end_users_end_user_id_accounts_get ..."
-      end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_end_user_accounts_v1_end_users_end_user_id_accounts_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_end_user_accounts_v1_end_users_end_user_id_accounts_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_end_user_accounts_v1_end_users_end_user_id_accounts_get, must be smaller than or equal to 100.'
@@ -899,23 +764,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_end_user_document_v1_end_users_end_user_id_documents_document_id_get ..."
       end
-      # verify the required parameter 'document_id' is set
-      if @api_client.config.client_side_validation && document_id.nil?
-        fail ArgumentError, "Missing the required parameter 'document_id' when calling PinwheelApi.get_end_user_document_v1_end_users_end_user_id_documents_document_id_get"
-      end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_end_user_document_v1_end_users_end_user_id_documents_document_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_end_user_document_v1_end_users_end_user_id_documents_document_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/end_users/{end_user_id}/documents/{document_id}".sub("{" + "document_id" + "}", CGI.escape(document_id.to_s).gsub("%2F", "/")).sub("{" + "end_user_id" + "}", CGI.escape(end_user_id.to_s).gsub("%2F", "/"))
 
@@ -979,19 +827,6 @@ module Pinwheel
     def get_end_user_documents_v1_end_users_end_user_id_documents_get_with_http_info(end_user_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_end_user_documents_v1_end_users_end_user_id_documents_get ..."
-      end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_end_user_documents_v1_end_users_end_user_id_documents_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_end_user_documents_v1_end_users_end_user_id_documents_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       allowable_values = ["direct_deposit_form"]
       if @api_client.config.client_side_validation && opts[:type] && !allowable_values.include?(opts[:type])
@@ -1060,19 +895,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_end_user_verification_reports_voe_v1_end_users_end_user_id_verification_reports_voe_get ..."
       end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_end_user_verification_reports_voe_v1_end_users_end_user_id_verification_reports_voe_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_end_user_verification_reports_voe_v1_end_users_end_user_id_verification_reports_voe_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/end_users/{end_user_id}/verification_reports/voe".sub("{" + "end_user_id" + "}", CGI.escape(end_user_id.to_s).gsub("%2F", "/"))
 
@@ -1134,19 +956,6 @@ module Pinwheel
     def get_end_user_verification_reports_voie_v1_end_users_end_user_id_verification_reports_voie_get_with_http_info(end_user_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_end_user_verification_reports_voie_v1_end_users_end_user_id_verification_reports_voie_get ..."
-      end
-      # verify the required parameter 'end_user_id' is set
-      if @api_client.config.client_side_validation && end_user_id.nil?
-        fail ArgumentError, "Missing the required parameter 'end_user_id' when calling PinwheelApi.get_end_user_verification_reports_voie_v1_end_users_end_user_id_verification_reports_voie_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_end_user_verification_reports_voie_v1_end_users_end_user_id_verification_reports_voie_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/end_users/{end_user_id}/verification_reports/voie".sub("{" + "end_user_id" + "}", CGI.escape(end_user_id.to_s).gsub("%2F", "/"))
@@ -1210,19 +1019,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_identity_v1_accounts_account_id_identity_get ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_identity_v1_accounts_account_id_identity_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_identity_v1_accounts_account_id_identity_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/accounts/{account_id}/identity".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
 
@@ -1284,19 +1080,6 @@ module Pinwheel
     def get_income_v1_accounts_account_id_income_get_with_http_info(account_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_income_v1_accounts_account_id_income_get ..."
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_income_v1_accounts_account_id_income_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_income_v1_accounts_account_id_income_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/accounts/{account_id}/income".sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
@@ -1374,16 +1157,7 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_jobs_v1_jobs_get ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_jobs_v1_jobs_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
-      allowable_values = ["direct_deposit_switch", "employment", "direct_deposit_allocations", "identity", "tax_forms", "income", "shifts", "paystubs", "direct_deposit_payment"]
+      allowable_values = ["shifts", "direct_deposit_allocations", "tax_forms", "direct_deposit_switch", "identity", "employment", "income", "direct_deposit_payment", "paystubs"]
       if @api_client.config.client_side_validation && opts[:job_types] && !opts[:job_types].all? { |item| allowable_values.include?(item) }
         fail ArgumentError, "invalid value for \"job_types\", must include one of #{allowable_values}"
       end
@@ -1471,23 +1245,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_paystub_v1_accounts_account_id_paystubs_paystub_id_get ..."
       end
-      # verify the required parameter 'paystub_id' is set
-      if @api_client.config.client_side_validation && paystub_id.nil?
-        fail ArgumentError, "Missing the required parameter 'paystub_id' when calling PinwheelApi.get_paystub_v1_accounts_account_id_paystubs_paystub_id_get"
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_paystub_v1_accounts_account_id_paystubs_paystub_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_paystub_v1_accounts_account_id_paystubs_paystub_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/accounts/{account_id}/paystubs/{paystub_id}".sub("{" + "paystub_id" + "}", CGI.escape(paystub_id.to_s).gsub("%2F", "/")).sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
 
@@ -1549,19 +1306,6 @@ module Pinwheel
     def get_platform_v1_platforms_platform_id_get_with_http_info(platform_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_platform_v1_platforms_platform_id_get ..."
-      end
-      # verify the required parameter 'platform_id' is set
-      if @api_client.config.client_side_validation && platform_id.nil?
-        fail ArgumentError, "Missing the required parameter 'platform_id' when calling PinwheelApi.get_platform_v1_platforms_platform_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_platform_v1_platforms_platform_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/platforms/{platform_id}".sub("{" + "platform_id" + "}", CGI.escape(platform_id.to_s).gsub("%2F", "/"))
@@ -1629,23 +1373,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_tax_form_v1_accounts_account_id_tax_forms_tax_form_id_get ..."
       end
-      # verify the required parameter 'tax_form_id' is set
-      if @api_client.config.client_side_validation && tax_form_id.nil?
-        fail ArgumentError, "Missing the required parameter 'tax_form_id' when calling PinwheelApi.get_tax_form_v1_accounts_account_id_tax_forms_tax_form_id_get"
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.get_tax_form_v1_accounts_account_id_tax_forms_tax_form_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_tax_form_v1_accounts_account_id_tax_forms_tax_form_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/accounts/{account_id}/tax_forms/{tax_form_id}".sub("{" + "tax_form_id" + "}", CGI.escape(tax_form_id.to_s).gsub("%2F", "/")).sub("{" + "account_id" + "}", CGI.escape(account_id.to_s).gsub("%2F", "/"))
 
@@ -1712,19 +1439,6 @@ module Pinwheel
     def get_v1_company_connections_company_connection_id_census_get_with_http_info(company_connection_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_company_connections_company_connection_id_census_get ..."
-      end
-      # verify the required parameter 'company_connection_id' is set
-      if @api_client.config.client_side_validation && company_connection_id.nil?
-        fail ArgumentError, "Missing the required parameter 'company_connection_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_census_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_company_connections_company_connection_id_census_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_company_connections_company_connection_id_census_get, must be smaller than or equal to 100.'
@@ -1802,19 +1516,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_company_connections_company_connection_id_employments_get ..."
       end
-      # verify the required parameter 'company_connection_id' is set
-      if @api_client.config.client_side_validation && company_connection_id.nil?
-        fail ArgumentError, "Missing the required parameter 'company_connection_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_employments_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_company_connections_company_connection_id_employments_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_company_connections_company_connection_id_employments_get, must be smaller than or equal to 100.'
       end
@@ -1887,19 +1588,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_company_connections_company_connection_id_get ..."
       end
-      # verify the required parameter 'company_connection_id' is set
-      if @api_client.config.client_side_validation && company_connection_id.nil?
-        fail ArgumentError, "Missing the required parameter 'company_connection_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_company_connections_company_connection_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/company_connections/{company_connection_id}".sub("{" + "company_connection_id" + "}", CGI.escape(company_connection_id.to_s).gsub("%2F", "/"))
 
@@ -1965,19 +1653,6 @@ module Pinwheel
     def get_v1_company_connections_company_connection_id_incomes_get_with_http_info(company_connection_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_company_connections_company_connection_id_incomes_get ..."
-      end
-      # verify the required parameter 'company_connection_id' is set
-      if @api_client.config.client_side_validation && company_connection_id.nil?
-        fail ArgumentError, "Missing the required parameter 'company_connection_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_incomes_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_company_connections_company_connection_id_incomes_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_company_connections_company_connection_id_incomes_get, must be smaller than or equal to 100.'
@@ -2061,23 +1736,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_company_connections_company_connection_id_paystubs_employee_external_id_get ..."
       end
-      # verify the required parameter 'company_connection_id' is set
-      if @api_client.config.client_side_validation && company_connection_id.nil?
-        fail ArgumentError, "Missing the required parameter 'company_connection_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_paystubs_employee_external_id_get"
-      end
-      # verify the required parameter 'employee_external_id' is set
-      if @api_client.config.client_side_validation && employee_external_id.nil?
-        fail ArgumentError, "Missing the required parameter 'employee_external_id' when calling PinwheelApi.get_v1_company_connections_company_connection_id_paystubs_employee_external_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_company_connections_company_connection_id_paystubs_employee_external_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_company_connections_company_connection_id_paystubs_employee_external_id_get, must be smaller than or equal to 100.'
       end
@@ -2155,15 +1813,6 @@ module Pinwheel
     def get_v1_employers_get_with_http_info(pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_employers_get ..."
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_employers_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_employers_get, must be smaller than or equal to 100.'
@@ -2248,24 +1897,11 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_search_get ..."
       end
-      # verify the required parameter 'q' is set
-      if @api_client.config.client_side_validation && q.nil?
-        fail ArgumentError, "Missing the required parameter 'q' when calling PinwheelApi.get_v1_search_get"
-      end
       if @api_client.config.client_side_validation && q.to_s.length < 1
         fail ArgumentError, 'invalid value for "q" when calling PinwheelApi.get_v1_search_get, the character length must be great than or equal to 1.'
       end
 
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_search_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
-      allowable_values = ["direct_deposit_switch", "employment", "direct_deposit_allocations", "identity", "tax_forms", "income", "shifts", "paystubs", "direct_deposit_payment"]
+      allowable_values = ["shifts", "direct_deposit_allocations", "tax_forms", "direct_deposit_switch", "identity", "employment", "income", "direct_deposit_payment", "paystubs"]
       if @api_client.config.client_side_validation && opts[:supported_jobs] && !opts[:supported_jobs].all? { |item| allowable_values.include?(item) }
         fail ArgumentError, "invalid value for \"supported_jobs\", must include one of #{allowable_values}"
       end
@@ -2355,15 +1991,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_v1_webhooks_get ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_v1_webhooks_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.get_v1_webhooks_get, must be smaller than or equal to 100.'
       end
@@ -2436,19 +2063,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.get_webhook_by_id_v1_webhooks_webhook_id_get ..."
       end
-      # verify the required parameter 'webhook_id' is set
-      if @api_client.config.client_side_validation && webhook_id.nil?
-        fail ArgumentError, "Missing the required parameter 'webhook_id' when calling PinwheelApi.get_webhook_by_id_v1_webhooks_webhook_id_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.get_webhook_by_id_v1_webhooks_webhook_id_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # resource path
       local_var_path = "/webhooks/{webhook_id}".sub("{" + "webhook_id" + "}", CGI.escape(webhook_id.to_s).gsub("%2F", "/"))
 
@@ -2516,15 +2130,6 @@ module Pinwheel
     def list_accounts_v1_accounts_get_with_http_info(pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_accounts_v1_accounts_get ..."
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_accounts_v1_accounts_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_accounts_v1_accounts_get, must be smaller than or equal to 100.'
@@ -2608,15 +2213,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_keys_v1_admin_api_keys_get ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_keys_v1_admin_api_keys_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_keys_v1_admin_api_keys_get, must be smaller than or equal to 100.'
       end
@@ -2697,19 +2293,6 @@ module Pinwheel
     def list_paystubs_v1_accounts_account_id_paystubs_get_with_http_info(account_id, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_paystubs_v1_accounts_account_id_paystubs_get ..."
-      end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.list_paystubs_v1_accounts_account_id_paystubs_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_paystubs_v1_accounts_account_id_paystubs_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_paystubs_v1_accounts_account_id_paystubs_get, must be smaller than or equal to 100.'
@@ -2792,15 +2375,6 @@ module Pinwheel
     def list_platforms_v1_platforms_get_with_http_info(pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_platforms_v1_platforms_get ..."
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_platforms_v1_platforms_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       allowable_values = ["payroll", "time_and_attendance", "tax"]
       if @api_client.config.client_side_validation && opts[:type] && !allowable_values.include?(opts[:type])
@@ -2893,19 +2467,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_shifts_v1_accounts_account_id_shifts_get ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.list_shifts_v1_accounts_account_id_shifts_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_shifts_v1_accounts_account_id_shifts_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_shifts_v1_accounts_account_id_shifts_get, must be smaller than or equal to 100.'
       end
@@ -2990,19 +2551,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_tax_forms_v1_accounts_account_id_tax_forms_get ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.list_tax_forms_v1_accounts_account_id_tax_forms_get"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_tax_forms_v1_accounts_account_id_tax_forms_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_tax_forms_v1_accounts_account_id_tax_forms_get, must be smaller than or equal to 100.'
       end
@@ -3079,15 +2627,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.list_v1_company_connections_get ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.list_v1_company_connections_get"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       if @api_client.config.client_side_validation && !opts[:limit].nil? && opts[:limit] > 100
         fail ArgumentError, 'invalid value for "opts[:"limit"]" when calling PinwheelApi.list_v1_company_connections_get, must be smaller than or equal to 100.'
       end
@@ -3162,19 +2701,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.patch_monitoring_status_v1_sandbox_accounts_account_id_patch ..."
       end
-      # verify the required parameter 'account_id' is set
-      if @api_client.config.client_side_validation && account_id.nil?
-        fail ArgumentError, "Missing the required parameter 'account_id' when calling PinwheelApi.patch_monitoring_status_v1_sandbox_accounts_account_id_patch"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.patch_monitoring_status_v1_sandbox_accounts_account_id_patch"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # verify the required parameter 'payroll_account_patch_monitoring_status' is set
       if @api_client.config.client_side_validation && payroll_account_patch_monitoring_status.nil?
         fail ArgumentError, "Missing the required parameter 'payroll_account_patch_monitoring_status' when calling PinwheelApi.patch_monitoring_status_v1_sandbox_accounts_account_id_patch"
@@ -3245,15 +2771,6 @@ module Pinwheel
     def post_v1_company_connect_link_tokens_post_with_http_info(pinwheel_version, company_connect_link_token_create, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.post_v1_company_connect_link_tokens_post ..."
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.post_v1_company_connect_link_tokens_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # verify the required parameter 'company_connect_link_token_create' is set
       if @api_client.config.client_side_validation && company_connect_link_token_create.nil?
@@ -3326,15 +2843,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.post_v1_company_connections_post ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.post_v1_company_connections_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # verify the required parameter 'company_connection_create' is set
       if @api_client.config.client_side_validation && company_connection_create.nil?
         fail ArgumentError, "Missing the required parameter 'company_connection_create' when calling PinwheelApi.post_v1_company_connections_post"
@@ -3406,15 +2914,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.post_v1_link_tokens_post ..."
       end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.post_v1_link_tokens_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # verify the required parameter 'link_token_create_v20231122' is set
       if @api_client.config.client_side_validation && link_token_create_v20231122.nil?
         fail ArgumentError, "Missing the required parameter 'link_token_create_v20231122' when calling PinwheelApi.post_v1_link_tokens_post"
@@ -3485,15 +2984,6 @@ module Pinwheel
     def post_v1_webhooks_post_with_http_info(pinwheel_version, webhook_create_v20230418, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.post_v1_webhooks_post ..."
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.post_v1_webhooks_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # verify the required parameter 'webhook_create_v20230418' is set
       if @api_client.config.client_side_validation && webhook_create_v20230418.nil?
@@ -3568,19 +3058,6 @@ module Pinwheel
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.put_v1_webhooks_webhook_id_put ..."
       end
-      # verify the required parameter 'webhook_id' is set
-      if @api_client.config.client_side_validation && webhook_id.nil?
-        fail ArgumentError, "Missing the required parameter 'webhook_id' when calling PinwheelApi.put_v1_webhooks_webhook_id_put"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.put_v1_webhooks_webhook_id_put"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
-      end
       # verify the required parameter 'webhook_update' is set
       if @api_client.config.client_side_validation && webhook_update.nil?
         fail ArgumentError, "Missing the required parameter 'webhook_update' when calling PinwheelApi.put_v1_webhooks_webhook_id_put"
@@ -3653,19 +3130,6 @@ module Pinwheel
     def revoke_key_v1_admin_api_keys_api_key_revoke_post_with_http_info(api_key, pinwheel_version, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PinwheelApi.revoke_key_v1_admin_api_keys_api_key_revoke_post ..."
-      end
-      # verify the required parameter 'api_key' is set
-      if @api_client.config.client_side_validation && api_key.nil?
-        fail ArgumentError, "Missing the required parameter 'api_key' when calling PinwheelApi.revoke_key_v1_admin_api_keys_api_key_revoke_post"
-      end
-      # verify the required parameter 'pinwheel_version' is set
-      if @api_client.config.client_side_validation && pinwheel_version.nil?
-        fail ArgumentError, "Missing the required parameter 'pinwheel_version' when calling PinwheelApi.revoke_key_v1_admin_api_keys_api_key_revoke_post"
-      end
-      # verify enum value
-      allowable_values = ["2023-11-22", "2023-07-18", "2023-04-18", "2022-09-09", "2022-06-22", "2022-03-02"]
-      if @api_client.config.client_side_validation && !allowable_values.include?(pinwheel_version)
-        fail ArgumentError, "invalid value for \"pinwheel_version\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = "/admin/api_keys/{api_key}/revoke".sub("{" + "api_key" + "}", CGI.escape(api_key.to_s).gsub("%2F", "/"))

--- a/lib/pinwheel/models/address_get_response_item.rb
+++ b/lib/pinwheel/models/address_get_response_item.rb
@@ -88,7 +88,15 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :raw,
+        :line1,
+        :line2,
+        :city,
+        :state,
+        :postal_code,
+        :country
+      ])
     end
 
     # Initializes the object
@@ -139,19 +147,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @raw.nil?
-        invalid_properties.push('invalid value for "raw", raw cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @raw.nil?
       country_validator = EnumAttributeValidator.new("String", ["US"])
       return false unless country_validator.valid?(@country)
       true

--- a/lib/pinwheel/models/allocation.rb
+++ b/lib/pinwheel/models/allocation.rb
@@ -73,7 +73,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :type,
+        :value,
+        :min_amount
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/allocation_account_obj_response.rb
+++ b/lib/pinwheel/models/allocation_account_obj_response.rb
@@ -101,7 +101,18 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :account_name,
+        :account_type,
+        :allocation_type,
+        :amount,
+        :bank_name,
+        :currency,
+        :masked_account_number,
+        :percentage,
+        :priority,
+        :routing_number
+      ])
     end
 
     # Initializes the object
@@ -165,14 +176,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @allocation_type.nil?
-        invalid_properties.push('invalid value for "allocation_type", allocation_type cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
       if !@masked_account_number.nil? && @masked_account_number.to_s.length > 4
         invalid_properties.push('invalid value for "masked_account_number", the character length must be smaller than or equal to 4.')
       end
@@ -190,10 +193,8 @@ module Pinwheel
       warn "[DEPRECATED] the `valid?` method is obsolete"
       account_type_validator = EnumAttributeValidator.new("String", ["checking", "savings", "debit_card", "pay_card"])
       return false unless account_type_validator.valid?(@account_type)
-      return false if @allocation_type.nil?
       allocation_type_validator = EnumAttributeValidator.new("String", ["amount", "percentage", "remainder"])
       return false unless allocation_type_validator.valid?(@allocation_type)
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       return false if !@masked_account_number.nil? && @masked_account_number.to_s.length > 4
@@ -234,15 +235,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] masked_account_number Value to be assigned
     def masked_account_number=(masked_account_number)
-      if masked_account_number.nil?
-        fail ArgumentError, "masked_account_number cannot be nil"
-      end
-
-      if masked_account_number.to_s.length > 4
+      if !masked_account_number.nil? && masked_account_number.to_s.length > 4
         fail ArgumentError, 'invalid value for "masked_account_number", the character length must be smaller than or equal to 4.'
       end
 
-      if masked_account_number.to_s.length < 2
+      if !masked_account_number.nil? && masked_account_number.to_s.length < 2
         fail ArgumentError, 'invalid value for "masked_account_number", the character length must be great than or equal to 2.'
       end
 

--- a/lib/pinwheel/models/annual_income_response_obj.rb
+++ b/lib/pinwheel/models/annual_income_response_obj.rb
@@ -67,7 +67,14 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :year,
+        :gross_pay_ytd,
+        :net_pay_ytd,
+        :total_deductions_ytd,
+        :total_reimbursements_ytd,
+        :total_taxes_ytd
+      ])
     end
 
     # Initializes the object
@@ -123,30 +130,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @year.nil?
-        invalid_properties.push('invalid value for "year", year cannot be nil.')
-      end
-
-      if @gross_pay_ytd.nil?
-        invalid_properties.push('invalid value for "gross_pay_ytd", gross_pay_ytd cannot be nil.')
-      end
-
-      if @net_pay_ytd.nil?
-        invalid_properties.push('invalid value for "net_pay_ytd", net_pay_ytd cannot be nil.')
-      end
-
-      if @total_deductions_ytd.nil?
-        invalid_properties.push('invalid value for "total_deductions_ytd", total_deductions_ytd cannot be nil.')
-      end
-
-      if @total_reimbursements_ytd.nil?
-        invalid_properties.push('invalid value for "total_reimbursements_ytd", total_reimbursements_ytd cannot be nil.')
-      end
-
-      if @total_taxes_ytd.nil?
-        invalid_properties.push('invalid value for "total_taxes_ytd", total_taxes_ytd cannot be nil.')
-      end
-
       if @earnings_ytds.nil?
         invalid_properties.push('invalid value for "earnings_ytds", earnings_ytds cannot be nil.')
       end
@@ -158,12 +141,6 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @year.nil?
-      return false if @gross_pay_ytd.nil?
-      return false if @net_pay_ytd.nil?
-      return false if @total_deductions_ytd.nil?
-      return false if @total_reimbursements_ytd.nil?
-      return false if @total_taxes_ytd.nil?
       return false if @earnings_ytds.nil?
       true
     end

--- a/lib/pinwheel/models/bank_account_details.rb
+++ b/lib/pinwheel/models/bank_account_details.rb
@@ -73,7 +73,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :type,
+        :routing_number,
+        :account_number
+      ])
     end
 
     # Initializes the object
@@ -165,15 +170,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] name Value to be assigned
     def name=(name)
-      if name.nil?
-        fail ArgumentError, "name cannot be nil"
-      end
-
-      if name.to_s.length > 30
+      if !name.nil? && name.to_s.length > 30
         fail ArgumentError, 'invalid value for "name", the character length must be smaller than or equal to 30.'
       end
 
-      if name.to_s.length < 2
+      if !name.nil? && name.to_s.length < 2
         fail ArgumentError, 'invalid value for "name", the character length must be great than or equal to 2.'
       end
 
@@ -193,20 +194,16 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] routing_number Value to be assigned
     def routing_number=(routing_number)
-      if routing_number.nil?
-        fail ArgumentError, "routing_number cannot be nil"
-      end
-
-      if routing_number.to_s.length > 9
+      if !routing_number.nil? && routing_number.to_s.length > 9
         fail ArgumentError, 'invalid value for "routing_number", the character length must be smaller than or equal to 9.'
       end
 
-      if routing_number.to_s.length < 9
+      if !routing_number.nil? && routing_number.to_s.length < 9
         fail ArgumentError, 'invalid value for "routing_number", the character length must be great than or equal to 9.'
       end
 
       pattern = /^[0-9]*$/
-      if !routing_number&.match?(pattern)
+      if !routing_number.nil? && routing_number !~ pattern
         fail ArgumentError, "invalid value for \"routing_number\", must conform to the pattern #{pattern}."
       end
 
@@ -216,16 +213,12 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] account_number Value to be assigned
     def account_number=(account_number)
-      if account_number.nil?
-        fail ArgumentError, "account_number cannot be nil"
-      end
-
-      if account_number.to_s.length < 6
+      if !account_number.nil? && account_number.to_s.length < 6
         fail ArgumentError, 'invalid value for "account_number", the character length must be great than or equal to 6.'
       end
 
       pattern = /^[0-9]*$/
-      if !account_number&.match?(pattern)
+      if !account_number.nil? && account_number !~ pattern
         fail ArgumentError, "invalid value for \"account_number\", must conform to the pattern #{pattern}."
       end
 

--- a/lib/pinwheel/models/company_connect.rb
+++ b/lib/pinwheel/models/company_connect.rb
@@ -38,7 +38,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :company_connection_id
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/company_connect_link_token_create.rb
+++ b/lib/pinwheel/models/company_connect_link_token_create.rb
@@ -83,7 +83,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :org_name,
+        :skip_intro_screen,
+        :platform_id,
+        :language
+      ])
     end
 
     # Initializes the object
@@ -135,10 +140,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @org_name.nil?
-        invalid_properties.push('invalid value for "org_name", org_name cannot be nil.')
-      end
-
       if @org_name.to_s.length > 30
         invalid_properties.push('invalid value for "org_name", the character length must be smaller than or equal to 30.')
       end
@@ -154,7 +155,6 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @org_name.nil?
       return false if @org_name.to_s.length > 30
       return false if @org_name.to_s.length < 3
       language_validator = EnumAttributeValidator.new("String", ["en", "es"])
@@ -165,15 +165,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] org_name Value to be assigned
     def org_name=(org_name)
-      if org_name.nil?
-        fail ArgumentError, "org_name cannot be nil"
-      end
-
-      if org_name.to_s.length > 30
+      if !org_name.nil? && org_name.to_s.length > 30
         fail ArgumentError, 'invalid value for "org_name", the character length must be smaller than or equal to 30.'
       end
 
-      if org_name.to_s.length < 3
+      if !org_name.nil? && org_name.to_s.length < 3
         fail ArgumentError, 'invalid value for "org_name", the character length must be great than or equal to 3.'
       end
 

--- a/lib/pinwheel/models/company_connect_link_token_obj_response.rb
+++ b/lib/pinwheel/models/company_connect_link_token_obj_response.rb
@@ -73,7 +73,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :mode,
+        :id,
+        :token,
+        :expires
+      ])
     end
 
     # Initializes the object
@@ -112,36 +117,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @token.nil?
-        invalid_properties.push('invalid value for "token", token cannot be nil.')
-      end
-
-      if @expires.nil?
-        invalid_properties.push('invalid value for "expires", expires cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @id.nil?
-      return false if @token.nil?
-      return false if @expires.nil?
       true
     end
 

--- a/lib/pinwheel/models/company_connection_base.rb
+++ b/lib/pinwheel/models/company_connection_base.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :company_name,
+        :status,
+        :status_updated_at
+      ])
     end
 
     # Initializes the object
@@ -121,41 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @company_name.nil?
-        invalid_properties.push('invalid value for "company_name", company_name cannot be nil.')
-      end
-
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
-      if @status_updated_at.nil?
-        invalid_properties.push('invalid value for "status_updated_at", status_updated_at cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @company_name.nil?
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["ready_to_connect", "connection_failed", "processing", "data_available", "reconnect_needed"])
       return false unless status_validator.valid?(@status)
-      return false if @status_updated_at.nil?
       true
     end
 

--- a/lib/pinwheel/models/company_connection_create.rb
+++ b/lib/pinwheel/models/company_connection_create.rb
@@ -37,7 +37,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :company_name
+      ])
     end
 
     # Initializes the object
@@ -64,19 +66,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @company_name.nil?
-        invalid_properties.push('invalid value for "company_name", company_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @company_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/company_employment_obj_response.rb
+++ b/lib/pinwheel/models/company_employment_obj_response.rb
@@ -112,7 +112,19 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :employee_external_id,
+        :status,
+        :employment_type,
+        :start_date,
+        :termination_date,
+        :employer_name,
+        :title,
+        :department,
+        :manager_external_id,
+        :class_code
+      ])
     end
 
     # Initializes the object
@@ -183,33 +195,17 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @employee_external_id.nil?
-        invalid_properties.push('invalid value for "employee_external_id", employee_external_id cannot be nil.')
-      end
-
-      if @employer_name.nil?
-        invalid_properties.push('invalid value for "employer_name", employer_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @employee_external_id.nil?
       status_validator = EnumAttributeValidator.new("String", ["employed", "terminated", "furloughed"])
       return false unless status_validator.valid?(@status)
       employment_type_validator = EnumAttributeValidator.new("String", ["full_time", "part_time", "seasonal", "temporary", "contractor", "self_employed", "per_diem", "commission"])
       return false unless employment_type_validator.valid?(@employment_type)
-      return false if @employer_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/company_identity_obj_response.rb
+++ b/lib/pinwheel/models/company_identity_obj_response.rb
@@ -87,7 +87,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :employee_external_id,
+        :date_of_birth,
+        :first_name,
+        :middle_name,
+        :last_name,
+        :last_four_ssn,
+        :full_name
+      ])
     end
 
     # Initializes the object
@@ -158,44 +167,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @employee_external_id.nil?
-        invalid_properties.push('invalid value for "employee_external_id", employee_external_id cannot be nil.')
-      end
-
-      if @first_name.nil?
-        invalid_properties.push('invalid value for "first_name", first_name cannot be nil.')
-      end
-
-      if @middle_name.nil?
-        invalid_properties.push('invalid value for "middle_name", middle_name cannot be nil.')
-      end
-
-      if @last_name.nil?
-        invalid_properties.push('invalid value for "last_name", last_name cannot be nil.')
-      end
-
-      if @full_name.nil?
-        invalid_properties.push('invalid value for "full_name", full_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @employee_external_id.nil?
-      return false if @first_name.nil?
-      return false if @middle_name.nil?
-      return false if @last_name.nil?
-      return false if @full_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/company_income_obj_response.rb
+++ b/lib/pinwheel/models/company_income_obj_response.rb
@@ -81,7 +81,14 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :employee_external_id,
+        :compensation_amount,
+        :compensation_unit,
+        :currency,
+        :pay_frequency
+      ])
     end
 
     # Initializes the object
@@ -128,41 +135,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @employee_external_id.nil?
-        invalid_properties.push('invalid value for "employee_external_id", employee_external_id cannot be nil.')
-      end
-
-      if @compensation_amount.nil?
-        invalid_properties.push('invalid value for "compensation_amount", compensation_amount cannot be nil.')
-      end
-
-      if @compensation_unit.nil?
-        invalid_properties.push('invalid value for "compensation_unit", compensation_unit cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @employee_external_id.nil?
-      return false if @compensation_amount.nil?
-      return false if @compensation_unit.nil?
       compensation_unit_validator = EnumAttributeValidator.new("String", ["hourly", "daily", "weekly", "bi-weekly", "semi-weekly", "monthly", "semi-monthly", "annually", "variable", "per_mile"])
       return false unless compensation_unit_validator.valid?(@compensation_unit)
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       pay_frequency_validator = EnumAttributeValidator.new("String", ["daily", "weekly", "bi-weekly", "monthly", "semi-monthly", "variable"])

--- a/lib/pinwheel/models/company_paystub_obj_response.rb
+++ b/lib/pinwheel/models/company_paystub_obj_response.rb
@@ -128,7 +128,23 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :employee_external_id,
+        :pay_date,
+        :pay_period_start,
+        :pay_period_end,
+        :currency,
+        :gross_pay_amount,
+        :net_pay_amount,
+        :check_amount,
+        :gross_pay_ytd,
+        :net_pay_ytd,
+        :total_taxes,
+        :total_deductions,
+        :total_reimbursements,
+        :employer_name
+      ])
     end
 
     # Initializes the object
@@ -211,66 +227,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @employee_external_id.nil?
-        invalid_properties.push('invalid value for "employee_external_id", employee_external_id cannot be nil.')
-      end
-
-      if @pay_date.nil?
-        invalid_properties.push('invalid value for "pay_date", pay_date cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      if @gross_pay_amount.nil?
-        invalid_properties.push('invalid value for "gross_pay_amount", gross_pay_amount cannot be nil.')
-      end
-
-      if @net_pay_amount.nil?
-        invalid_properties.push('invalid value for "net_pay_amount", net_pay_amount cannot be nil.')
-      end
-
-      if @check_amount.nil?
-        invalid_properties.push('invalid value for "check_amount", check_amount cannot be nil.')
-      end
-
-      if @total_taxes.nil?
-        invalid_properties.push('invalid value for "total_taxes", total_taxes cannot be nil.')
-      end
-
-      if @total_deductions.nil?
-        invalid_properties.push('invalid value for "total_deductions", total_deductions cannot be nil.')
-      end
-
-      if @total_reimbursements.nil?
-        invalid_properties.push('invalid value for "total_reimbursements", total_reimbursements cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @employee_external_id.nil?
-      return false if @pay_date.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
-      return false if @gross_pay_amount.nil?
-      return false if @net_pay_amount.nil?
-      return false if @check_amount.nil?
-      return false if @total_taxes.nil?
-      return false if @total_deductions.nil?
-      return false if @total_reimbursements.nil?
       true
     end
 

--- a/lib/pinwheel/models/create_admin_token_request.rb
+++ b/lib/pinwheel/models/create_admin_token_request.rb
@@ -42,7 +42,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :username,
+        :password
+      ])
     end
 
     # Initializes the object
@@ -73,24 +76,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @username.nil?
-        invalid_properties.push('invalid value for "username", username cannot be nil.')
-      end
-
-      if @password.nil?
-        invalid_properties.push('invalid value for "password", password cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @username.nil?
-      return false if @password.nil?
       true
     end
 

--- a/lib/pinwheel/models/create_admin_token_response_data.rb
+++ b/lib/pinwheel/models/create_admin_token_response_data.rb
@@ -77,7 +77,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :token,
+        :expiration,
+        :workspace_name,
+        :mode,
+        :user_role
+      ])
     end
 
     # Initializes the object
@@ -120,41 +126,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @token.nil?
-        invalid_properties.push('invalid value for "token", token cannot be nil.')
-      end
-
-      if @expiration.nil?
-        invalid_properties.push('invalid value for "expiration", expiration cannot be nil.')
-      end
-
-      if @workspace_name.nil?
-        invalid_properties.push('invalid value for "workspace_name", workspace_name cannot be nil.')
-      end
-
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @user_role.nil?
-        invalid_properties.push('invalid value for "user_role", user_role cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @token.nil?
-      return false if @expiration.nil?
-      return false if @workspace_name.nil?
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @user_role.nil?
       user_role_validator = EnumAttributeValidator.new("String", ["owner", "administrator", "developer"])
       return false unless user_role_validator.valid?(@user_role)
       true

--- a/lib/pinwheel/models/create_api_key_options.rb
+++ b/lib/pinwheel/models/create_api_key_options.rb
@@ -37,7 +37,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :expires_at
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/create_api_key_response_data.rb
+++ b/lib/pinwheel/models/create_api_key_response_data.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :mode,
+        :key,
+        :expires_at,
+        :created_at,
+        :secret
+      ])
     end
 
     # Initializes the object
@@ -121,36 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @key.nil?
-        invalid_properties.push('invalid value for "key", key cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @secret.nil?
-        invalid_properties.push('invalid value for "secret", secret cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @key.nil?
-      return false if @created_at.nil?
-      return false if @secret.nil?
       true
     end
 

--- a/lib/pinwheel/models/dd_allocation_obj_response.rb
+++ b/lib/pinwheel/models/dd_allocation_obj_response.rb
@@ -57,7 +57,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :account_id,
+        :created_at,
+        :updated_at
+      ])
     end
 
     # Initializes the object
@@ -105,22 +110,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
       if @allocations.nil?
         invalid_properties.push('invalid value for "allocations", allocations cannot be nil.')
       end
@@ -132,10 +121,6 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @account_id.nil?
-      return false if @created_at.nil?
-      return false if @updated_at.nil?
       return false if @allocations.nil?
       true
     end

--- a/lib/pinwheel/models/deduction_obj_public_response_item.rb
+++ b/lib/pinwheel/models/deduction_obj_public_response_item.rb
@@ -72,7 +72,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :amount,
+        :type
+      ])
     end
 
     # Initializes the object
@@ -111,36 +116,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @category.nil?
-        invalid_properties.push('invalid value for "category", category cannot be nil.')
-      end
-
-      if @amount.nil?
-        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
-      end
-
-      if @type.nil?
-        invalid_properties.push('invalid value for "type", type cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @name.nil?
-      return false if @category.nil?
       category_validator = EnumAttributeValidator.new("String", ["retirement", "medical_insurance", "hsa", "fsa", "dental", "vision", "life_insurance", "disability", "child_support", "commuter", "union_dues", "stock", "charity", "savings", "tips", "wage_garnishment", "lending", "company_perk", "tax", "loan", "job_expense", "other", "fees", "reallocation", "retro_pay"])
       return false unless category_validator.valid?(@category)
-      return false if @amount.nil?
-      return false if @type.nil?
       type_validator = EnumAttributeValidator.new("String", ["pre_tax", "post_tax", "unknown"])
       return false unless type_validator.valid?(@type)
       true

--- a/lib/pinwheel/models/direct_deposit_allocation_detail.rb
+++ b/lib/pinwheel/models/direct_deposit_allocation_detail.rb
@@ -68,7 +68,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :type,
+        :value
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/document_obj_public_response_item.rb
+++ b/lib/pinwheel/models/document_obj_public_response_item.rb
@@ -47,7 +47,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :download_url,
+        :download_url_expiration
+      ])
     end
 
     # Initializes the object
@@ -82,19 +86,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
       true
     end
 

--- a/lib/pinwheel/models/earning_obj_public_response_item.rb
+++ b/lib/pinwheel/models/earning_obj_public_response_item.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :amount,
+        :rate,
+        :hours
+      ])
     end
 
     # Initializes the object
@@ -121,31 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @category.nil?
-        invalid_properties.push('invalid value for "category", category cannot be nil.')
-      end
-
-      if @amount.nil?
-        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @name.nil?
-      return false if @category.nil?
       category_validator = EnumAttributeValidator.new("String", ["salary", "hourly", "overtime", "double_overtime", "premium", "bonus", "commission", "tips", "vacation", "holiday", "pto", "sick", "employer_contribution", "other", "fare", "unpaid", "parental", "shift_differential", "bereavement", "life_insurance", "stock", "retirement", "medical", "meal_comp", "disability", "retro_pay"])
       return false unless category_validator.valid?(@category)
-      return false if @amount.nil?
       true
     end
 

--- a/lib/pinwheel/models/earnings_stream_payout_obj_response_v20230418.rb
+++ b/lib/pinwheel/models/earnings_stream_payout_obj_response_v20230418.rb
@@ -73,7 +73,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :status,
+        :pay_date
+      ])
     end
 
     # Initializes the object
@@ -117,14 +120,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
-      if @pay_date.nil?
-        invalid_properties.push('invalid value for "pay_date", pay_date cannot be nil.')
-      end
-
       if @earnings.nil?
         invalid_properties.push('invalid value for "earnings", earnings cannot be nil.')
       end
@@ -136,10 +131,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["estimated", "processed"])
       return false unless status_validator.valid?(@status)
-      return false if @pay_date.nil?
       return false if @earnings.nil?
       true
     end

--- a/lib/pinwheel/models/earnings_ytds.rb
+++ b/lib/pinwheel/models/earnings_ytds.rb
@@ -63,7 +63,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :amount,
+        :category
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/employee_name.rb
+++ b/lib/pinwheel/models/employee_name.rb
@@ -52,7 +52,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :first_name,
+        :middle_name,
+        :last_name,
+        :full_name
+      ])
     end
 
     # Initializes the object
@@ -91,19 +96,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @full_name.nil?
-        invalid_properties.push('invalid value for "full_name", full_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @full_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/employee_name_and_address.rb
+++ b/lib/pinwheel/models/employee_name_and_address.rb
@@ -42,7 +42,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/employee_response_obj.rb
+++ b/lib/pinwheel/models/employee_response_obj.rb
@@ -57,7 +57,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :date_of_birth,
+        :last_four_ssn
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/employer_name_and_address.rb
+++ b/lib/pinwheel/models/employer_name_and_address.rb
@@ -42,7 +42,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/employer_obj_response.rb
+++ b/lib/pinwheel/models/employer_obj_response.rb
@@ -114,7 +114,19 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :name,
+        :last_updated,
+        :logo_url,
+        :fractional_amount_supported,
+        :amount_supported,
+        :min_amount,
+        :max_amount,
+        :min_percentage,
+        :max_percentage,
+        :percentage_supported
+      ])
     end
 
     # Initializes the object
@@ -190,18 +202,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @last_updated.nil?
-        invalid_properties.push('invalid value for "last_updated", last_updated cannot be nil.')
-      end
-
       if !@logo_url.nil? && @logo_url.to_s.length > 65536
         invalid_properties.push('invalid value for "logo_url", the character length must be smaller than or equal to 65536.')
       end
@@ -214,28 +214,12 @@ module Pinwheel
         invalid_properties.push('invalid value for "supported_jobs", supported_jobs cannot be nil.')
       end
 
-      if @fractional_amount_supported.nil?
-        invalid_properties.push('invalid value for "fractional_amount_supported", fractional_amount_supported cannot be nil.')
-      end
-
-      if @amount_supported.nil?
-        invalid_properties.push('invalid value for "amount_supported", amount_supported cannot be nil.')
-      end
-
-      if @min_percentage.nil?
-        invalid_properties.push('invalid value for "min_percentage", min_percentage cannot be nil.')
-      end
-
       if @min_percentage >= 100
         invalid_properties.push('invalid value for "min_percentage", must be smaller than 100.')
       end
 
       if @min_percentage <= 0
         invalid_properties.push('invalid value for "min_percentage", must be greater than 0.')
-      end
-
-      if @max_percentage.nil?
-        invalid_properties.push('invalid value for "max_percentage", max_percentage cannot be nil.')
       end
 
       if @max_percentage >= 100
@@ -246,10 +230,6 @@ module Pinwheel
         invalid_properties.push('invalid value for "max_percentage", must be greater than 0.')
       end
 
-      if @percentage_supported.nil?
-        invalid_properties.push('invalid value for "percentage_supported", percentage_supported cannot be nil.')
-      end
-
       invalid_properties
     end
 
@@ -257,36 +237,24 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @name.nil?
-      return false if @last_updated.nil?
       return false if !@logo_url.nil? && @logo_url.to_s.length > 65536
       return false if !@logo_url.nil? && @logo_url.to_s.length < 1
       return false if @supported_jobs.nil?
-      return false if @fractional_amount_supported.nil?
-      return false if @amount_supported.nil?
-      return false if @min_percentage.nil?
       return false if @min_percentage >= 100
       return false if @min_percentage <= 0
-      return false if @max_percentage.nil?
       return false if @max_percentage >= 100
       return false if @max_percentage <= 0
-      return false if @percentage_supported.nil?
       true
     end
 
     # Custom attribute writer method with validation
     # @param [Object] logo_url Value to be assigned
     def logo_url=(logo_url)
-      if logo_url.nil?
-        fail ArgumentError, "logo_url cannot be nil"
-      end
-
-      if logo_url.to_s.length > 65536
+      if !logo_url.nil? && logo_url.to_s.length > 65536
         fail ArgumentError, 'invalid value for "logo_url", the character length must be smaller than or equal to 65536.'
       end
 
-      if logo_url.to_s.length < 1
+      if !logo_url.nil? && logo_url.to_s.length < 1
         fail ArgumentError, 'invalid value for "logo_url", the character length must be great than or equal to 1.'
       end
 
@@ -296,15 +264,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] min_percentage Value to be assigned
     def min_percentage=(min_percentage)
-      if min_percentage.nil?
-        fail ArgumentError, "min_percentage cannot be nil"
-      end
-
-      if min_percentage >= 100
+      if !min_percentage.nil? && min_percentage >= 100
         fail ArgumentError, 'invalid value for "min_percentage", must be smaller than 100.'
       end
 
-      if min_percentage <= 0
+      if !min_percentage.nil? && min_percentage <= 0
         fail ArgumentError, 'invalid value for "min_percentage", must be greater than 0.'
       end
 
@@ -314,15 +278,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] max_percentage Value to be assigned
     def max_percentage=(max_percentage)
-      if max_percentage.nil?
-        fail ArgumentError, "max_percentage cannot be nil"
-      end
-
-      if max_percentage >= 100
+      if !max_percentage.nil? && max_percentage >= 100
         fail ArgumentError, 'invalid value for "max_percentage", must be smaller than 100.'
       end
 
-      if max_percentage <= 0
+      if !max_percentage.nil? && max_percentage <= 0
         fail ArgumentError, 'invalid value for "max_percentage", must be greater than 0.'
       end
 

--- a/lib/pinwheel/models/employment_obj_response.rb
+++ b/lib/pinwheel/models/employment_obj_response.rb
@@ -108,7 +108,17 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :updated_at,
+        :account_id,
+        :status,
+        :start_date,
+        :termination_date,
+        :employer_name,
+        :title
+      ])
     end
 
     # Initializes the object
@@ -175,41 +185,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @employer_name.nil?
-        invalid_properties.push('invalid value for "employer_name", employer_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @updated_at.nil?
-      return false if @account_id.nil?
       status_validator = EnumAttributeValidator.new("String", ["employed", "terminated", "furloughed"])
       return false unless status_validator.valid?(@status)
-      return false if @employer_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/employment_response_obj.rb
+++ b/lib/pinwheel/models/employment_response_obj.rb
@@ -98,7 +98,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :employer_name,
+        :start_date,
+        :employment_duration_months,
+        :employment_status,
+        :employment_type,
+        :termination_date,
+        :title,
+        :most_recent_pay_date
+      ])
     end
 
     # Initializes the object
@@ -157,19 +166,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @employer_name.nil?
-        invalid_properties.push('invalid value for "employer_name", employer_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @employer_name.nil?
       employment_status_validator = EnumAttributeValidator.new("String", ["employed", "terminated", "furloughed"])
       return false unless employment_status_validator.valid?(@employment_status)
       true

--- a/lib/pinwheel/models/end_user_document_obj_response.rb
+++ b/lib/pinwheel/models/end_user_document_obj_response.rb
@@ -87,7 +87,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :end_user_id,
+        :document_type
+      ])
     end
 
     # Initializes the object
@@ -141,20 +145,8 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @end_user_id.nil?
-        invalid_properties.push('invalid value for "end_user_id", end_user_id cannot be nil.')
-      end
-
       if @document.nil?
         invalid_properties.push('invalid value for "document", document cannot be nil.')
-      end
-
-      if @document_type.nil?
-        invalid_properties.push('invalid value for "document_type", document_type cannot be nil.')
       end
 
       invalid_properties
@@ -164,10 +156,7 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @end_user_id.nil?
       return false if @document.nil?
-      return false if @document_type.nil?
       document_type_validator = EnumAttributeValidator.new("String", ["paystub", "W-2", "1099", "direct_deposit_form", "verification_report", "1040"])
       return false unless document_type_validator.valid?(@document_type)
       true

--- a/lib/pinwheel/models/field_warning.rb
+++ b/lib/pinwheel/models/field_warning.rb
@@ -68,7 +68,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :field,
+        :status,
+        :message
+      ])
     end
 
     # Initializes the object
@@ -103,31 +107,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @field.nil?
-        invalid_properties.push('invalid value for "field", field cannot be nil.')
-      end
-
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
-      if @message.nil?
-        invalid_properties.push('invalid value for "message", message cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @field.nil?
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["unparsable"])
       return false unless status_validator.valid?(@status)
-      return false if @message.nil?
       true
     end
 

--- a/lib/pinwheel/models/freshness_pagination_list_meta.rb
+++ b/lib/pinwheel/models/freshness_pagination_list_meta.rb
@@ -52,7 +52,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :refreshed_at,
+        :updated_at,
+        :count,
+        :next_cursor
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/identity_obj_response.rb
+++ b/lib/pinwheel/models/identity_obj_response.rb
@@ -82,7 +82,15 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :updated_at,
+        :account_id,
+        :full_name,
+        :date_of_birth,
+        :last_four_ssn
+      ])
     end
 
     # Initializes the object
@@ -149,39 +157,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @full_name.nil?
-        invalid_properties.push('invalid value for "full_name", full_name cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @updated_at.nil?
-      return false if @account_id.nil?
-      return false if @full_name.nil?
       true
     end
 

--- a/lib/pinwheel/models/income_and_employment_response_obj.rb
+++ b/lib/pinwheel/models/income_and_employment_response_obj.rb
@@ -103,7 +103,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :employer_name,
+        :start_date,
+        :employment_duration_months,
+        :employment_status,
+        :employment_type,
+        :termination_date,
+        :title,
+        :most_recent_pay_date
+      ])
     end
 
     # Initializes the object
@@ -167,10 +176,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @employer_name.nil?
-        invalid_properties.push('invalid value for "employer_name", employer_name cannot be nil.')
-      end
-
       if @income.nil?
         invalid_properties.push('invalid value for "income", income cannot be nil.')
       end
@@ -182,7 +187,6 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @employer_name.nil?
       employment_status_validator = EnumAttributeValidator.new("String", ["employed", "terminated", "furloughed"])
       return false unless employment_status_validator.valid?(@employment_status)
       return false if @income.nil?

--- a/lib/pinwheel/models/income_obj_response.rb
+++ b/lib/pinwheel/models/income_obj_response.rb
@@ -91,7 +91,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :updated_at,
+        :account_id,
+        :compensation_amount,
+        :compensation_unit,
+        :currency,
+        :pay_frequency
+      ])
     end
 
     # Initializes the object
@@ -146,51 +155,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @compensation_amount.nil?
-        invalid_properties.push('invalid value for "compensation_amount", compensation_amount cannot be nil.')
-      end
-
-      if @compensation_unit.nil?
-        invalid_properties.push('invalid value for "compensation_unit", compensation_unit cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @updated_at.nil?
-      return false if @account_id.nil?
-      return false if @compensation_amount.nil?
-      return false if @compensation_unit.nil?
       compensation_unit_validator = EnumAttributeValidator.new("String", ["hourly", "daily", "weekly", "bi-weekly", "semi-weekly", "monthly", "semi-monthly", "annually", "variable", "per_mile"])
       return false unless compensation_unit_validator.valid?(@compensation_unit)
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       pay_frequency_validator = EnumAttributeValidator.new("String", ["daily", "weekly", "bi-weekly", "monthly", "semi-monthly", "variable"])

--- a/lib/pinwheel/models/income_response_obj.rb
+++ b/lib/pinwheel/models/income_response_obj.rb
@@ -81,7 +81,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :pay_frequency,
+        :compensation_unit,
+        :compensation_amount,
+        :currency
+      ])
     end
 
     # Initializes the object
@@ -137,18 +142,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @compensation_unit.nil?
-        invalid_properties.push('invalid value for "compensation_unit", compensation_unit cannot be nil.')
-      end
-
-      if @compensation_amount.nil?
-        invalid_properties.push('invalid value for "compensation_amount", compensation_amount cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
       if @annual_incomes.nil?
         invalid_properties.push('invalid value for "annual_incomes", annual_incomes cannot be nil.')
       end
@@ -166,11 +159,8 @@ module Pinwheel
       warn "[DEPRECATED] the `valid?` method is obsolete"
       pay_frequency_validator = EnumAttributeValidator.new("String", ["daily", "weekly", "bi-weekly", "monthly", "semi-monthly", "variable"])
       return false unless pay_frequency_validator.valid?(@pay_frequency)
-      return false if @compensation_unit.nil?
       compensation_unit_validator = EnumAttributeValidator.new("String", ["hourly", "daily", "weekly", "bi-weekly", "semi-weekly", "monthly", "semi-monthly", "annually", "variable", "per_mile"])
       return false unless compensation_unit_validator.valid?(@compensation_unit)
-      return false if @compensation_amount.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       return false if @annual_incomes.nil?

--- a/lib/pinwheel/models/job_obj_response_v20231122.rb
+++ b/lib/pinwheel/models/job_obj_response_v20231122.rb
@@ -97,7 +97,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :name,
+        :timestamp,
+        :outcome,
+        :error_code,
+        :error_type,
+        :link_token_id,
+        :account_id
+      ])
     end
 
     # Initializes the object
@@ -156,50 +165,24 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @timestamp.nil?
-        invalid_properties.push('invalid value for "timestamp", timestamp cannot be nil.')
-      end
-
-      if @outcome.nil?
-        invalid_properties.push('invalid value for "outcome", outcome cannot be nil.')
-      end
-
-      if @link_token_id.nil?
-        invalid_properties.push('invalid value for "link_token_id", link_token_id cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @name.nil?
-      name_validator = EnumAttributeValidator.new("String", ["direct_deposit_switch", "employment", "direct_deposit_allocations", "identity", "tax_forms", "income", "shifts", "paystubs", "direct_deposit_payment"])
+      name_validator = EnumAttributeValidator.new("String", ["shifts", "direct_deposit_allocations", "tax_forms", "direct_deposit_switch", "identity", "employment", "income", "direct_deposit_payment", "paystubs"])
       return false unless name_validator.valid?(@name)
-      return false if @timestamp.nil?
-      return false if @outcome.nil?
       outcome_validator = EnumAttributeValidator.new("String", ["pending", "error", "success"])
       return false unless outcome_validator.valid?(@outcome)
-      return false if @link_token_id.nil?
       true
     end
 
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] name Object to be assigned
     def name=(name)
-      validator = EnumAttributeValidator.new("String", ["direct_deposit_switch", "employment", "direct_deposit_allocations", "identity", "tax_forms", "income", "shifts", "paystubs", "direct_deposit_payment"])
+      validator = EnumAttributeValidator.new("String", ["shifts", "direct_deposit_allocations", "tax_forms", "direct_deposit_switch", "identity", "employment", "income", "direct_deposit_payment", "paystubs"])
       unless validator.valid?(name)
         fail ArgumentError, "invalid value for \"name\", must be one of #{validator.allowable_values}."
       end

--- a/lib/pinwheel/models/link_token_create_v20231122.rb
+++ b/lib/pinwheel/models/link_token_create_v20231122.rb
@@ -125,7 +125,19 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :org_name,
+        :skip_intro_screen,
+        :employer_id,
+        :disable_direct_deposit_splitting,
+        :platform_id,
+        :platform_type,
+        :language,
+        :end_user_id,
+        :account_id,
+        :document_uploads,
+        :deposit_forms
+      ])
     end
 
     # Initializes the object
@@ -217,10 +229,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @org_name.nil?
-        invalid_properties.push('invalid value for "org_name", org_name cannot be nil.')
-      end
-
       if @org_name.to_s.length > 30
         invalid_properties.push('invalid value for "org_name", the character length must be smaller than or equal to 30.')
       end
@@ -244,7 +252,6 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @org_name.nil?
       return false if @org_name.to_s.length > 30
       return false if @org_name.to_s.length < 3
       platform_type_validator = EnumAttributeValidator.new("String", ["payroll", "time_and_attendance", "tax"])
@@ -263,15 +270,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] org_name Value to be assigned
     def org_name=(org_name)
-      if org_name.nil?
-        fail ArgumentError, "org_name cannot be nil"
-      end
-
-      if org_name.to_s.length > 30
+      if !org_name.nil? && org_name.to_s.length > 30
         fail ArgumentError, 'invalid value for "org_name", the character length must be smaller than or equal to 30.'
       end
 
-      if org_name.to_s.length < 3
+      if !org_name.nil? && org_name.to_s.length < 3
         fail ArgumentError, 'invalid value for "org_name", the character length must be great than or equal to 3.'
       end
 
@@ -301,15 +304,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] end_user_id Value to be assigned
     def end_user_id=(end_user_id)
-      if end_user_id.nil?
-        fail ArgumentError, "end_user_id cannot be nil"
-      end
-
-      if end_user_id.to_s.length > 255
+      if !end_user_id.nil? && end_user_id.to_s.length > 255
         fail ArgumentError, 'invalid value for "end_user_id", the character length must be smaller than or equal to 255.'
       end
 
-      if end_user_id.to_s.length < 1
+      if !end_user_id.nil? && end_user_id.to_s.length < 1
         fail ArgumentError, 'invalid value for "end_user_id", the character length must be great than or equal to 1.'
       end
 

--- a/lib/pinwheel/models/link_token_obj_response_v20210728.rb
+++ b/lib/pinwheel/models/link_token_obj_response_v20210728.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :mode,
+        :id,
+        :token,
+        :smart_branch_url,
+        :expires
+      ])
     end
 
     # Initializes the object
@@ -121,36 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @token.nil?
-        invalid_properties.push('invalid value for "token", token cannot be nil.')
-      end
-
-      if @expires.nil?
-        invalid_properties.push('invalid value for "expires", expires cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @id.nil?
-      return false if @token.nil?
-      return false if @expires.nil?
       true
     end
 

--- a/lib/pinwheel/models/link_user_authentication_data_obj_create.rb
+++ b/lib/pinwheel/models/link_user_authentication_data_obj_create.rb
@@ -72,7 +72,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :social_security_number,
+        :social_security_number_last_four,
+        :date_of_birth,
+        :last_name,
+        :first_name,
+        :mobile_phone_number,
+        :home_address_zip_code,
+        :email
+      ])
     end
 
     # Initializes the object
@@ -205,20 +214,16 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] social_security_number Value to be assigned
     def social_security_number=(social_security_number)
-      if social_security_number.nil?
-        fail ArgumentError, "social_security_number cannot be nil"
-      end
-
-      if social_security_number.to_s.length > 9
+      if !social_security_number.nil? && social_security_number.to_s.length > 9
         fail ArgumentError, 'invalid value for "social_security_number", the character length must be smaller than or equal to 9.'
       end
 
-      if social_security_number.to_s.length < 9
+      if !social_security_number.nil? && social_security_number.to_s.length < 9
         fail ArgumentError, 'invalid value for "social_security_number", the character length must be great than or equal to 9.'
       end
 
       pattern = /^[0-9]*$/
-      if !social_security_number&.match?(pattern)
+      if !social_security_number.nil? && social_security_number !~ pattern
         fail ArgumentError, "invalid value for \"social_security_number\", must conform to the pattern #{pattern}."
       end
 
@@ -228,20 +233,16 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] social_security_number_last_four Value to be assigned
     def social_security_number_last_four=(social_security_number_last_four)
-      if social_security_number_last_four.nil?
-        fail ArgumentError, "social_security_number_last_four cannot be nil"
-      end
-
-      if social_security_number_last_four.to_s.length > 4
+      if !social_security_number_last_four.nil? && social_security_number_last_four.to_s.length > 4
         fail ArgumentError, 'invalid value for "social_security_number_last_four", the character length must be smaller than or equal to 4.'
       end
 
-      if social_security_number_last_four.to_s.length < 4
+      if !social_security_number_last_four.nil? && social_security_number_last_four.to_s.length < 4
         fail ArgumentError, 'invalid value for "social_security_number_last_four", the character length must be great than or equal to 4.'
       end
 
       pattern = /^[0-9]*$/
-      if !social_security_number_last_four&.match?(pattern)
+      if !social_security_number_last_four.nil? && social_security_number_last_four !~ pattern
         fail ArgumentError, "invalid value for \"social_security_number_last_four\", must conform to the pattern #{pattern}."
       end
 
@@ -251,20 +252,16 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] mobile_phone_number Value to be assigned
     def mobile_phone_number=(mobile_phone_number)
-      if mobile_phone_number.nil?
-        fail ArgumentError, "mobile_phone_number cannot be nil"
-      end
-
-      if mobile_phone_number.to_s.length > 10
+      if !mobile_phone_number.nil? && mobile_phone_number.to_s.length > 10
         fail ArgumentError, 'invalid value for "mobile_phone_number", the character length must be smaller than or equal to 10.'
       end
 
-      if mobile_phone_number.to_s.length < 10
+      if !mobile_phone_number.nil? && mobile_phone_number.to_s.length < 10
         fail ArgumentError, 'invalid value for "mobile_phone_number", the character length must be great than or equal to 10.'
       end
 
       pattern = /^[0-9]*$/
-      if !mobile_phone_number&.match?(pattern)
+      if !mobile_phone_number.nil? && mobile_phone_number !~ pattern
         fail ArgumentError, "invalid value for \"mobile_phone_number\", must conform to the pattern #{pattern}."
       end
 
@@ -274,20 +271,16 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] home_address_zip_code Value to be assigned
     def home_address_zip_code=(home_address_zip_code)
-      if home_address_zip_code.nil?
-        fail ArgumentError, "home_address_zip_code cannot be nil"
-      end
-
-      if home_address_zip_code.to_s.length > 5
+      if !home_address_zip_code.nil? && home_address_zip_code.to_s.length > 5
         fail ArgumentError, 'invalid value for "home_address_zip_code", the character length must be smaller than or equal to 5.'
       end
 
-      if home_address_zip_code.to_s.length < 5
+      if !home_address_zip_code.nil? && home_address_zip_code.to_s.length < 5
         fail ArgumentError, 'invalid value for "home_address_zip_code", the character length must be great than or equal to 5.'
       end
 
       pattern = /^[0-9]*$/
-      if !home_address_zip_code&.match?(pattern)
+      if !home_address_zip_code.nil? && home_address_zip_code !~ pattern
         fail ArgumentError, "invalid value for \"home_address_zip_code\", must conform to the pattern #{pattern}."
       end
 

--- a/lib/pinwheel/models/list_api_key_response_data.rb
+++ b/lib/pinwheel/models/list_api_key_response_data.rb
@@ -88,7 +88,15 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :mode,
+        :key,
+        :expires_at,
+        :created_at,
+        :last_used_at,
+        :is_active,
+        :revoked_at
+      ])
     end
 
     # Initializes the object
@@ -139,36 +147,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @key.nil?
-        invalid_properties.push('invalid value for "key", key cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @is_active.nil?
-        invalid_properties.push('invalid value for "is_active", is_active cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @key.nil?
-      return false if @created_at.nil?
-      return false if @is_active.nil?
       true
     end
 

--- a/lib/pinwheel/models/list_meta.rb
+++ b/lib/pinwheel/models/list_meta.rb
@@ -37,7 +37,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :count
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/net_pay_obj_response.rb
+++ b/lib/pinwheel/models/net_pay_obj_response.rb
@@ -63,7 +63,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :amount,
+        :currency
+      ])
     end
 
     # Initializes the object
@@ -94,24 +97,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @amount.nil?
-        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @amount.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       true

--- a/lib/pinwheel/models/pagination_meta.rb
+++ b/lib/pinwheel/models/pagination_meta.rb
@@ -42,7 +42,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :count,
+        :next_cursor
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/params_payload_v20231122.rb
+++ b/lib/pinwheel/models/params_payload_v20231122.rb
@@ -106,7 +106,18 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :document_type,
+        :pay_date,
+        :year,
+        :count,
+        :from_pay_date,
+        :to_pay_date,
+        :has_potential_paystubs_documents,
+        :sync_status,
+        :card_name,
+        :action
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/payroll_account_data_refreshed.rb
+++ b/lib/pinwheel/models/payroll_account_data_refreshed.rb
@@ -62,7 +62,14 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :direct_deposit_allocations,
+        :income,
+        :employment,
+        :identity,
+        :shifts,
+        :paystubs
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/payroll_account_data_updated.rb
+++ b/lib/pinwheel/models/payroll_account_data_updated.rb
@@ -62,7 +62,14 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :direct_deposit_allocations,
+        :income,
+        :employment,
+        :identity,
+        :shifts,
+        :paystubs
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/payroll_account_obj_response.rb
+++ b/lib/pinwheel/models/payroll_account_obj_response.rb
@@ -98,7 +98,15 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :created_at,
+        :link_token_id,
+        :platform_id,
+        :connected,
+        :monitoring_status,
+        :end_user_id,
+        :id
+      ])
     end
 
     # Initializes the object
@@ -158,30 +166,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @platform_id.nil?
-        invalid_properties.push('invalid value for "platform_id", platform_id cannot be nil.')
-      end
-
-      if @connected.nil?
-        invalid_properties.push('invalid value for "connected", connected cannot be nil.')
-      end
-
-      if @monitoring_status.nil?
-        invalid_properties.push('invalid value for "monitoring_status", monitoring_status cannot be nil.')
-      end
-
-      if @end_user_id.nil?
-        invalid_properties.push('invalid value for "end_user_id", end_user_id cannot be nil.')
-      end
-
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
       if @data_updated_at.nil?
         invalid_properties.push('invalid value for "data_updated_at", data_updated_at cannot be nil.')
       end
@@ -197,14 +181,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @created_at.nil?
-      return false if @platform_id.nil?
-      return false if @connected.nil?
-      return false if @monitoring_status.nil?
       monitoring_status_validator = EnumAttributeValidator.new("String", ["active", "degraded", "user_action_required", "customer_disabled", "unavailable"])
       return false unless monitoring_status_validator.valid?(@monitoring_status)
-      return false if @end_user_id.nil?
-      return false if @id.nil?
       return false if @data_updated_at.nil?
       return false if @data_refreshed_at.nil?
       true

--- a/lib/pinwheel/models/payroll_account_patch_monitoring_status.rb
+++ b/lib/pinwheel/models/payroll_account_patch_monitoring_status.rb
@@ -58,7 +58,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :monitoring_status
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/paystub_obj_response_v20220302.rb
+++ b/lib/pinwheel/models/paystub_obj_response_v20220302.rb
@@ -163,7 +163,25 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :account_id,
+        :pay_date,
+        :pay_period_start,
+        :pay_period_end,
+        :currency,
+        :gross_pay_amount,
+        :net_pay_amount,
+        :check_amount,
+        :gross_pay_ytd,
+        :net_pay_ytd,
+        :total_taxes,
+        :total_deductions,
+        :total_reimbursements,
+        :external_paystub_id,
+        :employer_name
+      ])
     end
 
     # Initializes the object
@@ -291,50 +309,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @pay_date.nil?
-        invalid_properties.push('invalid value for "pay_date", pay_date cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      if @gross_pay_amount.nil?
-        invalid_properties.push('invalid value for "gross_pay_amount", gross_pay_amount cannot be nil.')
-      end
-
-      if @net_pay_amount.nil?
-        invalid_properties.push('invalid value for "net_pay_amount", net_pay_amount cannot be nil.')
-      end
-
-      if @check_amount.nil?
-        invalid_properties.push('invalid value for "check_amount", check_amount cannot be nil.')
-      end
-
-      if @total_taxes.nil?
-        invalid_properties.push('invalid value for "total_taxes", total_taxes cannot be nil.')
-      end
-
-      if @total_deductions.nil?
-        invalid_properties.push('invalid value for "total_deductions", total_deductions cannot be nil.')
-      end
-
-      if @total_reimbursements.nil?
-        invalid_properties.push('invalid value for "total_reimbursements", total_reimbursements cannot be nil.')
-      end
-
       if @taxes.nil?
         invalid_properties.push('invalid value for "taxes", taxes cannot be nil.')
       end
@@ -358,19 +332,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @account_id.nil?
-      return false if @pay_date.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
-      return false if @gross_pay_amount.nil?
-      return false if @net_pay_amount.nil?
-      return false if @check_amount.nil?
-      return false if @total_taxes.nil?
-      return false if @total_deductions.nil?
-      return false if @total_reimbursements.nil?
       return false if @taxes.nil?
       return false if @deductions.nil?
       return false if @earnings.nil?

--- a/lib/pinwheel/models/paystub_with_earnings_response_obj.rb
+++ b/lib/pinwheel/models/paystub_with_earnings_response_obj.rb
@@ -143,7 +143,25 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :account_id,
+        :pay_date,
+        :pay_period_start,
+        :pay_period_end,
+        :currency,
+        :gross_pay_amount,
+        :net_pay_amount,
+        :check_amount,
+        :gross_pay_ytd,
+        :net_pay_ytd,
+        :total_taxes,
+        :total_deductions,
+        :total_reimbursements,
+        :external_paystub_id,
+        :employer_name
+      ])
     end
 
     # Initializes the object
@@ -243,50 +261,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @pay_date.nil?
-        invalid_properties.push('invalid value for "pay_date", pay_date cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
-      end
-
-      if @gross_pay_amount.nil?
-        invalid_properties.push('invalid value for "gross_pay_amount", gross_pay_amount cannot be nil.')
-      end
-
-      if @net_pay_amount.nil?
-        invalid_properties.push('invalid value for "net_pay_amount", net_pay_amount cannot be nil.')
-      end
-
-      if @check_amount.nil?
-        invalid_properties.push('invalid value for "check_amount", check_amount cannot be nil.')
-      end
-
-      if @total_taxes.nil?
-        invalid_properties.push('invalid value for "total_taxes", total_taxes cannot be nil.')
-      end
-
-      if @total_deductions.nil?
-        invalid_properties.push('invalid value for "total_deductions", total_deductions cannot be nil.')
-      end
-
-      if @total_reimbursements.nil?
-        invalid_properties.push('invalid value for "total_reimbursements", total_reimbursements cannot be nil.')
-      end
-
       if @earnings.nil?
         invalid_properties.push('invalid value for "earnings", earnings cannot be nil.')
       end
@@ -298,19 +272,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @account_id.nil?
-      return false if @pay_date.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
-      return false if @gross_pay_amount.nil?
-      return false if @net_pay_amount.nil?
-      return false if @check_amount.nil?
-      return false if @total_taxes.nil?
-      return false if @total_deductions.nil?
-      return false if @total_reimbursements.nil?
       return false if @earnings.nil?
       true
     end

--- a/lib/pinwheel/models/phone_number_get_response_item.rb
+++ b/lib/pinwheel/models/phone_number_get_response_item.rb
@@ -63,7 +63,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :value,
+        :type
+      ])
     end
 
     # Initializes the object
@@ -94,19 +97,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @value.nil?
-        invalid_properties.push('invalid value for "value", value cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @value.nil?
       type_validator = EnumAttributeValidator.new("String", ["home", "work", "mobile"])
       return false unless type_validator.valid?(@type)
       true

--- a/lib/pinwheel/models/platform_obj_response.rb
+++ b/lib/pinwheel/models/platform_obj_response.rb
@@ -118,7 +118,20 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :name,
+        :type,
+        :fractional_amount_supported,
+        :min_amount,
+        :max_amount,
+        :last_updated,
+        :logo_url,
+        :percentage_supported,
+        :min_percentage,
+        :max_percentage,
+        :amount_supported
+      ])
     end
 
     # Initializes the object
@@ -198,32 +211,12 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @type.nil?
-        invalid_properties.push('invalid value for "type", type cannot be nil.')
-      end
-
-      if @fractional_amount_supported.nil?
-        invalid_properties.push('invalid value for "fractional_amount_supported", fractional_amount_supported cannot be nil.')
-      end
-
       if !@min_amount.nil? && @min_amount <= 0.0
         invalid_properties.push('invalid value for "min_amount", must be greater than 0.0.')
       end
 
       if !@max_amount.nil? && @max_amount <= 0.0
         invalid_properties.push('invalid value for "max_amount", must be greater than 0.0.')
-      end
-
-      if @last_updated.nil?
-        invalid_properties.push('invalid value for "last_updated", last_updated cannot be nil.')
       end
 
       if !@logo_url.nil? && @logo_url.to_s.length > 65536
@@ -234,24 +227,12 @@ module Pinwheel
         invalid_properties.push('invalid value for "logo_url", the character length must be great than or equal to 1.')
       end
 
-      if @percentage_supported.nil?
-        invalid_properties.push('invalid value for "percentage_supported", percentage_supported cannot be nil.')
-      end
-
-      if @min_percentage.nil?
-        invalid_properties.push('invalid value for "min_percentage", min_percentage cannot be nil.')
-      end
-
       if @min_percentage >= 100
         invalid_properties.push('invalid value for "min_percentage", must be smaller than 100.')
       end
 
       if @min_percentage <= 0
         invalid_properties.push('invalid value for "min_percentage", must be greater than 0.')
-      end
-
-      if @max_percentage.nil?
-        invalid_properties.push('invalid value for "max_percentage", max_percentage cannot be nil.')
       end
 
       if @max_percentage >= 100
@@ -266,10 +247,6 @@ module Pinwheel
         invalid_properties.push('invalid value for "supported_jobs", supported_jobs cannot be nil.')
       end
 
-      if @amount_supported.nil?
-        invalid_properties.push('invalid value for "amount_supported", amount_supported cannot be nil.')
-      end
-
       invalid_properties
     end
 
@@ -277,26 +254,17 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @name.nil?
-      return false if @type.nil?
       type_validator = EnumAttributeValidator.new("String", ["payroll", "time_and_attendance", "tax"])
       return false unless type_validator.valid?(@type)
-      return false if @fractional_amount_supported.nil?
       return false if !@min_amount.nil? && @min_amount <= 0.0
       return false if !@max_amount.nil? && @max_amount <= 0.0
-      return false if @last_updated.nil?
       return false if !@logo_url.nil? && @logo_url.to_s.length > 65536
       return false if !@logo_url.nil? && @logo_url.to_s.length < 1
-      return false if @percentage_supported.nil?
-      return false if @min_percentage.nil?
       return false if @min_percentage >= 100
       return false if @min_percentage <= 0
-      return false if @max_percentage.nil?
       return false if @max_percentage >= 100
       return false if @max_percentage <= 0
       return false if @supported_jobs.nil?
-      return false if @amount_supported.nil?
       true
     end
 
@@ -313,11 +281,7 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] min_amount Value to be assigned
     def min_amount=(min_amount)
-      if min_amount.nil?
-        fail ArgumentError, "min_amount cannot be nil"
-      end
-
-      if min_amount <= 0.0
+      if !min_amount.nil? && min_amount <= 0.0
         fail ArgumentError, 'invalid value for "min_amount", must be greater than 0.0.'
       end
 
@@ -327,11 +291,7 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] max_amount Value to be assigned
     def max_amount=(max_amount)
-      if max_amount.nil?
-        fail ArgumentError, "max_amount cannot be nil"
-      end
-
-      if max_amount <= 0.0
+      if !max_amount.nil? && max_amount <= 0.0
         fail ArgumentError, 'invalid value for "max_amount", must be greater than 0.0.'
       end
 
@@ -341,15 +301,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] logo_url Value to be assigned
     def logo_url=(logo_url)
-      if logo_url.nil?
-        fail ArgumentError, "logo_url cannot be nil"
-      end
-
-      if logo_url.to_s.length > 65536
+      if !logo_url.nil? && logo_url.to_s.length > 65536
         fail ArgumentError, 'invalid value for "logo_url", the character length must be smaller than or equal to 65536.'
       end
 
-      if logo_url.to_s.length < 1
+      if !logo_url.nil? && logo_url.to_s.length < 1
         fail ArgumentError, 'invalid value for "logo_url", the character length must be great than or equal to 1.'
       end
 
@@ -359,15 +315,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] min_percentage Value to be assigned
     def min_percentage=(min_percentage)
-      if min_percentage.nil?
-        fail ArgumentError, "min_percentage cannot be nil"
-      end
-
-      if min_percentage >= 100
+      if !min_percentage.nil? && min_percentage >= 100
         fail ArgumentError, 'invalid value for "min_percentage", must be smaller than 100.'
       end
 
-      if min_percentage <= 0
+      if !min_percentage.nil? && min_percentage <= 0
         fail ArgumentError, 'invalid value for "min_percentage", must be greater than 0.'
       end
 
@@ -377,15 +329,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] max_percentage Value to be assigned
     def max_percentage=(max_percentage)
-      if max_percentage.nil?
-        fail ArgumentError, "max_percentage cannot be nil"
-      end
-
-      if max_percentage >= 100
+      if !max_percentage.nil? && max_percentage >= 100
         fail ArgumentError, 'invalid value for "max_percentage", must be smaller than 100.'
       end
 
-      if max_percentage <= 0
+      if !max_percentage.nil? && max_percentage <= 0
         fail ArgumentError, 'invalid value for "max_percentage", must be greater than 0.'
       end
 

--- a/lib/pinwheel/models/refreshable_meta.rb
+++ b/lib/pinwheel/models/refreshable_meta.rb
@@ -37,7 +37,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :refreshed_at
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/refreshable_pagination_list_meta.rb
+++ b/lib/pinwheel/models/refreshable_pagination_list_meta.rb
@@ -47,7 +47,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :refreshed_at,
+        :count,
+        :next_cursor
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/revoke_api_key_response_data.rb
+++ b/lib/pinwheel/models/revoke_api_key_response_data.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :mode,
+        :key,
+        :expires_at,
+        :created_at,
+        :revoked_at
+      ])
     end
 
     # Initializes the object
@@ -121,36 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @mode.nil?
-        invalid_properties.push('invalid value for "mode", mode cannot be nil.')
-      end
-
-      if @key.nil?
-        invalid_properties.push('invalid value for "key", key cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @revoked_at.nil?
-        invalid_properties.push('invalid value for "revoked_at", revoked_at cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @mode.nil?
       mode_validator = EnumAttributeValidator.new("String", ["sandbox", "development", "production"])
       return false unless mode_validator.valid?(@mode)
-      return false if @key.nil?
-      return false if @created_at.nil?
-      return false if @revoked_at.nil?
       true
     end
 

--- a/lib/pinwheel/models/search_result_obj_response.rb
+++ b/lib/pinwheel/models/search_result_obj_response.rb
@@ -122,7 +122,21 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :name,
+        :platform_type,
+        :last_updated,
+        :logo_url,
+        :fractional_amount_supported,
+        :amount_supported,
+        :min_amount,
+        :max_amount,
+        :response_type,
+        :min_percentage,
+        :max_percentage,
+        :percentage_supported
+      ])
     end
 
     # Initializes the object
@@ -206,18 +220,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @last_updated.nil?
-        invalid_properties.push('invalid value for "last_updated", last_updated cannot be nil.')
-      end
-
       if !@logo_url.nil? && @logo_url.to_s.length > 65536
         invalid_properties.push('invalid value for "logo_url", the character length must be smaller than or equal to 65536.')
       end
@@ -230,40 +232,12 @@ module Pinwheel
         invalid_properties.push('invalid value for "supported_jobs", supported_jobs cannot be nil.')
       end
 
-      if @fractional_amount_supported.nil?
-        invalid_properties.push('invalid value for "fractional_amount_supported", fractional_amount_supported cannot be nil.')
-      end
-
-      if @amount_supported.nil?
-        invalid_properties.push('invalid value for "amount_supported", amount_supported cannot be nil.')
-      end
-
-      if @min_amount.nil?
-        invalid_properties.push('invalid value for "min_amount", min_amount cannot be nil.')
-      end
-
-      if @max_amount.nil?
-        invalid_properties.push('invalid value for "max_amount", max_amount cannot be nil.')
-      end
-
-      if @response_type.nil?
-        invalid_properties.push('invalid value for "response_type", response_type cannot be nil.')
-      end
-
-      if @min_percentage.nil?
-        invalid_properties.push('invalid value for "min_percentage", min_percentage cannot be nil.')
-      end
-
       if @min_percentage >= 100
         invalid_properties.push('invalid value for "min_percentage", must be smaller than 100.')
       end
 
       if @min_percentage <= 0
         invalid_properties.push('invalid value for "min_percentage", must be greater than 0.')
-      end
-
-      if @max_percentage.nil?
-        invalid_properties.push('invalid value for "max_percentage", max_percentage cannot be nil.')
       end
 
       if @max_percentage >= 100
@@ -274,10 +248,6 @@ module Pinwheel
         invalid_properties.push('invalid value for "max_percentage", must be greater than 0.')
       end
 
-      if @percentage_supported.nil?
-        invalid_properties.push('invalid value for "percentage_supported", percentage_supported cannot be nil.')
-      end
-
       invalid_properties
     end
 
@@ -285,28 +255,17 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @name.nil?
       platform_type_validator = EnumAttributeValidator.new("String", ["payroll", "time_and_attendance", "tax"])
       return false unless platform_type_validator.valid?(@platform_type)
-      return false if @last_updated.nil?
       return false if !@logo_url.nil? && @logo_url.to_s.length > 65536
       return false if !@logo_url.nil? && @logo_url.to_s.length < 1
       return false if @supported_jobs.nil?
-      return false if @fractional_amount_supported.nil?
-      return false if @amount_supported.nil?
-      return false if @min_amount.nil?
-      return false if @max_amount.nil?
-      return false if @response_type.nil?
       response_type_validator = EnumAttributeValidator.new("String", ["employer", "platform"])
       return false unless response_type_validator.valid?(@response_type)
-      return false if @min_percentage.nil?
       return false if @min_percentage >= 100
       return false if @min_percentage <= 0
-      return false if @max_percentage.nil?
       return false if @max_percentage >= 100
       return false if @max_percentage <= 0
-      return false if @percentage_supported.nil?
       true
     end
 
@@ -323,15 +282,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] logo_url Value to be assigned
     def logo_url=(logo_url)
-      if logo_url.nil?
-        fail ArgumentError, "logo_url cannot be nil"
-      end
-
-      if logo_url.to_s.length > 65536
+      if !logo_url.nil? && logo_url.to_s.length > 65536
         fail ArgumentError, 'invalid value for "logo_url", the character length must be smaller than or equal to 65536.'
       end
 
-      if logo_url.to_s.length < 1
+      if !logo_url.nil? && logo_url.to_s.length < 1
         fail ArgumentError, 'invalid value for "logo_url", the character length must be great than or equal to 1.'
       end
 
@@ -351,15 +306,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] min_percentage Value to be assigned
     def min_percentage=(min_percentage)
-      if min_percentage.nil?
-        fail ArgumentError, "min_percentage cannot be nil"
-      end
-
-      if min_percentage >= 100
+      if !min_percentage.nil? && min_percentage >= 100
         fail ArgumentError, 'invalid value for "min_percentage", must be smaller than 100.'
       end
 
-      if min_percentage <= 0
+      if !min_percentage.nil? && min_percentage <= 0
         fail ArgumentError, 'invalid value for "min_percentage", must be greater than 0.'
       end
 
@@ -369,15 +320,11 @@ module Pinwheel
     # Custom attribute writer method with validation
     # @param [Object] max_percentage Value to be assigned
     def max_percentage=(max_percentage)
-      if max_percentage.nil?
-        fail ArgumentError, "max_percentage cannot be nil"
-      end
-
-      if max_percentage >= 100
+      if !max_percentage.nil? && max_percentage >= 100
         fail ArgumentError, 'invalid value for "max_percentage", must be smaller than 100.'
       end
 
-      if max_percentage <= 0
+      if !max_percentage.nil? && max_percentage <= 0
         fail ArgumentError, 'invalid value for "max_percentage", must be greater than 0.'
       end
 

--- a/lib/pinwheel/models/shared_fraud.rb
+++ b/lib/pinwheel/models/shared_fraud.rb
@@ -58,7 +58,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :status
+      ])
     end
 
     # Initializes the object
@@ -85,19 +87,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["suspected", "not_suspected", "unavailable"])
       return false unless status_validator.valid?(@status)
       true

--- a/lib/pinwheel/models/shift_earning_obj_public_response_item.rb
+++ b/lib/pinwheel/models/shift_earning_obj_public_response_item.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :amount,
+        :rate,
+        :hours
+      ])
     end
 
     # Initializes the object
@@ -121,24 +127,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @category.nil?
-        invalid_properties.push('invalid value for "category", category cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @name.nil?
-      return false if @category.nil?
       category_validator = EnumAttributeValidator.new("String", ["salary", "hourly", "overtime", "double_overtime", "premium", "bonus", "commission", "tips", "vacation", "holiday", "pto", "sick", "employer_contribution", "other", "fare", "unpaid", "parental", "shift_differential", "bereavement", "life_insurance", "stock", "retirement", "medical", "meal_comp", "disability", "retro_pay"])
       return false unless category_validator.valid?(@category)
       true

--- a/lib/pinwheel/models/shift_obj_response.rb
+++ b/lib/pinwheel/models/shift_obj_response.rb
@@ -102,7 +102,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :account_id,
+        :start_date,
+        :end_date,
+        :type,
+        :timezone,
+        :currency
+      ])
     end
 
     # Initializes the object
@@ -174,36 +183,8 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @start_date.nil?
-        invalid_properties.push('invalid value for "start_date", start_date cannot be nil.')
-      end
-
-      if @end_date.nil?
-        invalid_properties.push('invalid value for "end_date", end_date cannot be nil.')
-      end
-
-      if @type.nil?
-        invalid_properties.push('invalid value for "type", type cannot be nil.')
-      end
-
       if @timestamps.nil?
         invalid_properties.push('invalid value for "timestamps", timestamps cannot be nil.')
-      end
-
-      if @currency.nil?
-        invalid_properties.push('invalid value for "currency", currency cannot be nil.')
       end
 
       if @earnings.nil?
@@ -217,16 +198,9 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @account_id.nil?
-      return false if @start_date.nil?
-      return false if @end_date.nil?
-      return false if @type.nil?
       type_validator = EnumAttributeValidator.new("String", ["shift", "rideshare", "delivery", "other"])
       return false unless type_validator.valid?(@type)
       return false if @timestamps.nil?
-      return false if @currency.nil?
       currency_validator = EnumAttributeValidator.new("String", ["AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "INR", "IQD", "IRR", "ISK", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LTL", "LVL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "USN", "USS", "UYI", "UYU", "UZS", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XTS", "XXX", "YER", "ZAR", "ZMW"])
       return false unless currency_validator.valid?(@currency)
       return false if @earnings.nil?

--- a/lib/pinwheel/models/shift_timestamp.rb
+++ b/lib/pinwheel/models/shift_timestamp.rb
@@ -42,7 +42,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :from,
+        :to
+      ])
     end
 
     # Initializes the object
@@ -73,24 +76,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @from.nil?
-        invalid_properties.push('invalid value for "from", from cannot be nil.')
-      end
-
-      if @to.nil?
-        invalid_properties.push('invalid value for "to", to cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @from.nil?
-      return false if @to.nil?
       true
     end
 

--- a/lib/pinwheel/models/target_account.rb
+++ b/lib/pinwheel/models/target_account.rb
@@ -63,7 +63,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :account_name,
+        :account_type
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/tax_form_obj_response_no_document_v20220622.rb
+++ b/lib/pinwheel/models/tax_form_obj_response_no_document_v20220622.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :account_id,
+        :form_type,
+        :year
+      ])
     end
 
     # Initializes the object
@@ -121,41 +127,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @form_type.nil?
-        invalid_properties.push('invalid value for "form_type", form_type cannot be nil.')
-      end
-
-      if @year.nil?
-        invalid_properties.push('invalid value for "year", year cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @account_id.nil?
-      return false if @form_type.nil?
       form_type_validator = EnumAttributeValidator.new("String", ["W-2", "W-2C", "1099-NEC", "1099-MISC", "1099-K", "1040"])
       return false unless form_type_validator.valid?(@form_type)
-      return false if @year.nil?
       true
     end
 

--- a/lib/pinwheel/models/tax_form_obj_response_v20220622.rb
+++ b/lib/pinwheel/models/tax_form_obj_response_v20220622.rb
@@ -93,7 +93,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :created_at,
+        :account_id,
+        :form_type,
+        :year
+      ])
     end
 
     # Initializes the object
@@ -150,41 +156,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @account_id.nil?
-        invalid_properties.push('invalid value for "account_id", account_id cannot be nil.')
-      end
-
-      if @form_type.nil?
-        invalid_properties.push('invalid value for "form_type", form_type cannot be nil.')
-      end
-
-      if @year.nil?
-        invalid_properties.push('invalid value for "year", year cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @account_id.nil?
-      return false if @form_type.nil?
       form_type_validator = EnumAttributeValidator.new("String", ["W-2", "W-2C", "1099-NEC", "1099-MISC", "1099-K", "1040"])
       return false unless form_type_validator.valid?(@form_type)
-      return false if @year.nil?
       true
     end
 

--- a/lib/pinwheel/models/tax_form_w2.rb
+++ b/lib/pinwheel/models/tax_form_w2.rb
@@ -164,7 +164,24 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :document_type,
+        :box_a,
+        :box_b,
+        :box_d,
+        :box_e,
+        :box_1,
+        :box_2,
+        :box_3,
+        :box_4,
+        :box_5,
+        :box_6,
+        :box_7,
+        :box_8,
+        :box_9,
+        :box_10,
+        :box_11
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/tax_obj_public_response_item.rb
+++ b/lib/pinwheel/models/tax_obj_public_response_item.rb
@@ -68,7 +68,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :amount
+      ])
     end
 
     # Initializes the object
@@ -103,31 +107,15 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @category.nil?
-        invalid_properties.push('invalid value for "category", category cannot be nil.')
-      end
-
-      if @amount.nil?
-        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @name.nil?
-      return false if @category.nil?
       category_validator = EnumAttributeValidator.new("String", ["federal_income", "social_security", "medicare", "state_income", "local_income", "other"])
       return false unless category_validator.valid?(@category)
-      return false if @amount.nil?
       true
     end
 

--- a/lib/pinwheel/models/time_off_obj_public_response_item.rb
+++ b/lib/pinwheel/models/time_off_obj_public_response_item.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :available_hours,
+        :earned_hours,
+        :used_hours
+      ])
     end
 
     # Initializes the object
@@ -121,24 +127,13 @@ module Pinwheel
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
-      invalid_properties = []
-      if @name.nil?
-        invalid_properties.push('invalid value for "name", name cannot be nil.')
-      end
-
-      if @category.nil?
-        invalid_properties.push('invalid value for "category", category cannot be nil.')
-      end
-
-      invalid_properties
+      []
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @name.nil?
-      return false if @category.nil?
       category_validator = EnumAttributeValidator.new("String", ["pto", "sick", "other"])
       return false unless category_validator.valid?(@category)
       true

--- a/lib/pinwheel/models/uploaded_deduction.rb
+++ b/lib/pinwheel/models/uploaded_deduction.rb
@@ -52,7 +52,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :type,
+        :description,
+        :amount,
+        :amount_ytd
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/uploaded_earning.rb
+++ b/lib/pinwheel/models/uploaded_earning.rb
@@ -52,7 +52,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :type,
+        :description,
+        :amount,
+        :amount_ytd
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/uploaded_paystub.rb
+++ b/lib/pinwheel/models/uploaded_paystub.rb
@@ -124,7 +124,16 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :document_type,
+        :pay_date,
+        :pay_period_start,
+        :pay_period_end,
+        :gross_pay_amount,
+        :gross_pay_ytd,
+        :net_pay_amount,
+        :net_pay_ytd
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/uploaded_tax.rb
+++ b/lib/pinwheel/models/uploaded_tax.rb
@@ -52,7 +52,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :type,
+        :description,
+        :amount,
+        :amount_ytd
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/uploaded_time_off.rb
+++ b/lib/pinwheel/models/uploaded_time_off.rb
@@ -78,7 +78,13 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name,
+        :category,
+        :available_hours,
+        :earned_hours,
+        :used_hours
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/verification_reports_voe_obj_response.rb
+++ b/lib/pinwheel/models/verification_reports_voe_obj_response.rb
@@ -88,7 +88,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :updated_at,
+        :refreshed_at,
+        :report_type
+      ])
     end
 
     # Initializes the object
@@ -144,28 +149,12 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
-      if @refreshed_at.nil?
-        invalid_properties.push('invalid value for "refreshed_at", refreshed_at cannot be nil.')
-      end
-
       if @employee.nil?
         invalid_properties.push('invalid value for "employee", employee cannot be nil.')
       end
 
       if @employments.nil?
         invalid_properties.push('invalid value for "employments", employments cannot be nil.')
-      end
-
-      if @report_type.nil?
-        invalid_properties.push('invalid value for "report_type", report_type cannot be nil.')
       end
 
       invalid_properties
@@ -175,12 +164,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @updated_at.nil?
-      return false if @refreshed_at.nil?
       return false if @employee.nil?
       return false if @employments.nil?
-      return false if @report_type.nil?
       report_type_validator = EnumAttributeValidator.new("String", ["voe", "voie", "base"])
       return false unless report_type_validator.valid?(@report_type)
       true

--- a/lib/pinwheel/models/verification_reports_voie_obj_response.rb
+++ b/lib/pinwheel/models/verification_reports_voie_obj_response.rb
@@ -88,7 +88,12 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :id,
+        :updated_at,
+        :refreshed_at,
+        :report_type
+      ])
     end
 
     # Initializes the object
@@ -144,28 +149,12 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @updated_at.nil?
-        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
-      end
-
-      if @refreshed_at.nil?
-        invalid_properties.push('invalid value for "refreshed_at", refreshed_at cannot be nil.')
-      end
-
       if @employee.nil?
         invalid_properties.push('invalid value for "employee", employee cannot be nil.')
       end
 
       if @employments.nil?
         invalid_properties.push('invalid value for "employments", employments cannot be nil.')
-      end
-
-      if @report_type.nil?
-        invalid_properties.push('invalid value for "report_type", report_type cannot be nil.')
       end
 
       invalid_properties
@@ -175,12 +164,8 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @id.nil?
-      return false if @updated_at.nil?
-      return false if @refreshed_at.nil?
       return false if @employee.nil?
       return false if @employments.nil?
-      return false if @report_type.nil?
       report_type_validator = EnumAttributeValidator.new("String", ["voe", "voie", "base"])
       return false unless report_type_validator.valid?(@report_type)
       true

--- a/lib/pinwheel/models/w2_box12.rb
+++ b/lib/pinwheel/models/w2_box12.rb
@@ -42,7 +42,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :code,
+        :amount
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/w2_box13.rb
+++ b/lib/pinwheel/models/w2_box13.rb
@@ -47,7 +47,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :statutory_employee,
+        :retirement_plan,
+        :third_party_sick_pay
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/w2_box15_to20.rb
+++ b/lib/pinwheel/models/w2_box15_to20.rb
@@ -67,7 +67,15 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :box_15_state,
+        :box_15_employer_state_id,
+        :box_16,
+        :box_17,
+        :box_18,
+        :box_19,
+        :box_20
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/w2_box_c.rb
+++ b/lib/pinwheel/models/w2_box_c.rb
@@ -42,7 +42,9 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :name
+      ])
     end
 
     # Initializes the object

--- a/lib/pinwheel/models/webhook_create.rb
+++ b/lib/pinwheel/models/webhook_create.rb
@@ -72,7 +72,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :url,
+        :status,
+        :version
+      ])
     end
 
     # Initializes the object
@@ -116,14 +120,6 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @url.nil?
-        invalid_properties.push('invalid value for "url", url cannot be nil.')
-      end
-
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
       if @enabled_events.nil?
         invalid_properties.push('invalid value for "enabled_events", enabled_events cannot be nil.')
       end
@@ -139,13 +135,11 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @url.nil?
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["active", "paused"])
       return false unless status_validator.valid?(@status)
       return false if @enabled_events.nil?
       return false if @enabled_events.length < 1
-      version_validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      version_validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       return false unless version_validator.valid?(@version)
       true
     end
@@ -163,7 +157,7 @@ module Pinwheel
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] version Object to be assigned
     def version=(version)
-      validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       unless validator.valid?(version)
         fail ArgumentError, "invalid value for \"version\", must be one of #{validator.allowable_values}."
       end

--- a/lib/pinwheel/models/webhook_create_v20230418.rb
+++ b/lib/pinwheel/models/webhook_create_v20230418.rb
@@ -72,7 +72,11 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :url,
+        :status,
+        :version
+      ])
     end
 
     # Initializes the object
@@ -116,24 +120,12 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @url.nil?
-        invalid_properties.push('invalid value for "url", url cannot be nil.')
-      end
-
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
       if @enabled_events.nil?
         invalid_properties.push('invalid value for "enabled_events", enabled_events cannot be nil.')
       end
 
       if @enabled_events.length < 1
         invalid_properties.push('invalid value for "enabled_events", number of items must be greater than or equal to 1.')
-      end
-
-      if @version.nil?
-        invalid_properties.push('invalid value for "version", version cannot be nil.')
       end
 
       invalid_properties
@@ -143,14 +135,11 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @url.nil?
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["active", "paused"])
       return false unless status_validator.valid?(@status)
       return false if @enabled_events.nil?
       return false if @enabled_events.length < 1
-      return false if @version.nil?
-      version_validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      version_validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       return false unless version_validator.valid?(@version)
       true
     end
@@ -168,7 +157,7 @@ module Pinwheel
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] version Object to be assigned
     def version=(version)
-      validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       unless validator.valid?(version)
         fail ArgumentError, "invalid value for \"version\", must be one of #{validator.allowable_values}."
       end

--- a/lib/pinwheel/models/webhook_obj_response.rb
+++ b/lib/pinwheel/models/webhook_obj_response.rb
@@ -87,7 +87,14 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :url,
+        :status,
+        :version,
+        :id,
+        :created_at,
+        :last_updated
+      ])
     end
 
     # Initializes the object
@@ -143,36 +150,12 @@ module Pinwheel
     def list_invalid_properties
       warn "[DEPRECATED] the `list_invalid_properties` method is obsolete"
       invalid_properties = []
-      if @url.nil?
-        invalid_properties.push('invalid value for "url", url cannot be nil.')
-      end
-
-      if @status.nil?
-        invalid_properties.push('invalid value for "status", status cannot be nil.')
-      end
-
       if @enabled_events.nil?
         invalid_properties.push('invalid value for "enabled_events", enabled_events cannot be nil.')
       end
 
       if @enabled_events.length < 1
         invalid_properties.push('invalid value for "enabled_events", number of items must be greater than or equal to 1.')
-      end
-
-      if @version.nil?
-        invalid_properties.push('invalid value for "version", version cannot be nil.')
-      end
-
-      if @id.nil?
-        invalid_properties.push('invalid value for "id", id cannot be nil.')
-      end
-
-      if @created_at.nil?
-        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
-      end
-
-      if @last_updated.nil?
-        invalid_properties.push('invalid value for "last_updated", last_updated cannot be nil.')
       end
 
       invalid_properties
@@ -182,18 +165,12 @@ module Pinwheel
     # @return true if the model is valid
     def valid?
       warn "[DEPRECATED] the `valid?` method is obsolete"
-      return false if @url.nil?
-      return false if @status.nil?
       status_validator = EnumAttributeValidator.new("String", ["active", "paused"])
       return false unless status_validator.valid?(@status)
       return false if @enabled_events.nil?
       return false if @enabled_events.length < 1
-      return false if @version.nil?
-      version_validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      version_validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       return false unless version_validator.valid?(@version)
-      return false if @id.nil?
-      return false if @created_at.nil?
-      return false if @last_updated.nil?
       true
     end
 
@@ -210,7 +187,7 @@ module Pinwheel
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] version Object to be assigned
     def version=(version)
-      validator = EnumAttributeValidator.new("String", ["2022-09-09", "2023-11-22", "2023-04-18", "2023-07-18"])
+      validator = EnumAttributeValidator.new("String", ["2023-04-18", "2022-09-09", "2023-07-18", "2023-11-22"])
       unless validator.valid?(version)
         fail ArgumentError, "invalid value for \"version\", must be one of #{validator.allowable_values}."
       end

--- a/lib/pinwheel/models/webhook_update.rb
+++ b/lib/pinwheel/models/webhook_update.rb
@@ -68,7 +68,10 @@ module Pinwheel
 
     # List of attributes with nullable: true
     def self.openapi_nullable
-      Set.new([])
+      Set.new([
+        :url,
+        :status
+      ])
     end
 
     # Initializes the object


### PR DESCRIPTION
Per https://openapi-generator.tech/docs/customization/#openapi-normalizer

Based on behavior observed in the wild, seems like these values are generally expected to be nullable (at least in some environments). The SDK as-generated blows up on a number of fields.